### PR TITLE
Rework topDamager rewards

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/util/Rewards.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/util/Rewards.kt
@@ -2,6 +2,7 @@ package com.willfp.ecobosses.util
 
 import com.willfp.eco.core.drops.DropQueue
 import com.willfp.eco.util.NumberUtils
+import com.willfp.eco.util.formatEco
 import com.willfp.ecobosses.bosses.EcoBoss
 import com.willfp.ecobosses.events.BossTryDropItemEvent
 import org.bukkit.Bukkit
@@ -56,5 +57,49 @@ data class XpReward(
 ) {
     fun modify(event: EntityDeathEvent) {
         event.droppedExp = NumberUtils.randInt(minimum, maximum)
+    }
+}
+
+data class MultipleRewards(
+    val chance: Double,
+    val message: String,
+    val messageRadius: Double,
+    val commands: Collection<String>,
+    val items: Collection<ItemStack>,
+    val xpMinimum: Int,
+    val xpMaximum: Int
+) {
+    fun reward(player: Player): Boolean {
+        if (NumberUtils.randFloat(0.0, 100.0) < chance) {
+            //Run commands for a player
+            for (command in commands) {
+                Bukkit.getServer().dispatchCommand(
+                    Bukkit.getConsoleSender(),
+                    command.replace("%player%", player.name)
+                )
+            }
+
+            //Drop items to a player
+            DropQueue(player)
+                .setLocation(player.location)
+                .addItems(items)
+                .push()
+
+            //Give XP to a player
+            player.giveExp(NumberUtils.randInt(xpMinimum, xpMaximum))
+
+            //Broadcast message to nearby players
+            if(messageRadius > 0){
+                for (nearbyPlayer in player.getNearbyEntities(messageRadius, messageRadius, messageRadius)
+                    .filterIsInstance<Player>())
+                {
+                    nearbyPlayer.sendMessage(message.replace("%player%", player.name).formatEco())
+                }
+                player.sendMessage(message.replace("%player%", player.name).formatEco())
+            }
+
+            return true
+        }
+        return false
     }
 }

--- a/eco-core/core-plugin/src/main/resources/ecobosses.yml
+++ b/eco-core/core-plugin/src/main/resources/ecobosses.yml
@@ -77,6 +77,41 @@ bosses:
         - chance: 100
           items:
             - diamond_sword unbreaking:1 name:"Example Sword"
+      topDamagerRewards:
+        # If enabled this rewards will be given to top damager players
+        # and it disables "topDamagerCommands"
+        enabled: false
+        # If enabled, only one reward will be given to a player
+        # Disabled = player can get all rewards if lucky
+        getOnlyOneReward: true
+        # You can specify as many ranks as you want (adding 4, 5, etc)
+        # You can use %player% as a placeholder for the player name
+        rewards:
+          1:
+            # You can specify as many rewards as you want
+            # Keep lower chances at the top, for better results
+            - chance: 1
+              message: "&a%player% got Super rare Sword!" # Display message for players in radius if this reward is won
+              radius: 10 # Radius of message, set 0 to disable
+              commands: # You can use %player% as a placeholder for the player name
+                - eco give %player% 5000
+              items:
+                - diamond_sword sharpness:5 name:"Super rare Sword"
+              experience:
+                minimum: 20000
+                maximum: 30000
+            - chance: 100
+              message: "&c%player% got normal drop."
+              radius: 20
+              commands:
+                - eco give %player% 1000
+              items:
+                - diamond_shovel unbreaking:1 name:"Example Shovel"
+              xp:
+                minimum: 500
+                maximum: 1000
+          2: [ ]
+          3: [ ]
     target:
       # How the boss should choose which player to attack, choices are:
       # highest_health, lowest_health, closest, random


### PR DESCRIPTION
As I was talking with Auxilor on discord few days ago, I've tried to rework it by myself.

Added `enabled: true` so players can choose if they want to use new or old system.
Added `getOnlyOneReward: true` so players can force only one reward (before it could give more if players were lucky).
Added `message: "&a%player% got Super rare Sword!"` and radius so players can display message if someone got super rare drop.
