### PR TITLE
Fix spawning bosses on unloaded chunks

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/bosses/BossUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/bosses/BossUtils.kt
@@ -14,7 +14,7 @@ val Player.bossHolders: Iterable<Holder>
 
         for (boss in Bosses.values()) {
             for (livingBoss in boss.getAllAlive()) {
-                val entity = livingBoss.entity ?: continue
+                val entity = livingBoss.entity
 
                 if (entity.world != this.world) {
                     continue

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/bosses/EcoBoss.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/bosses/EcoBoss.kt
@@ -332,7 +332,7 @@ class EcoBoss(
 
         val boss = LivingEcoBoss(
             plugin,
-            mob.uniqueId,
+            mob,
             this,
             createTickers()
         )
@@ -345,7 +345,8 @@ class EcoBoss(
             LifespanTicker(),
             DisplayNameTicker(),
             TargetTicker(),
-            TeleportHandler()
+            TeleportHandler(),
+            ChunkTicker()
         )
 
         if (isBossBarEnabled) {
@@ -371,7 +372,7 @@ class EcoBoss(
     }
 
     fun processRewards(event: BossKillEvent) {
-        val entity = event.boss.entity ?: return
+        val entity = event.boss.entity
         val location = entity.location
         val player = event.killer
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/bosses/TargetMode.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/bosses/TargetMode.kt
@@ -17,7 +17,7 @@ class TargetMode(
     }
 
     fun getTarget(boss: LivingEcoBoss): LivingEntity? {
-        val entity = boss.entity ?: return null
+        val entity = boss.entity
 
         return function(
             entity.getNearbyEntities(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/lifecycle/ConsoleLoggers.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/lifecycle/ConsoleLoggers.kt
@@ -34,8 +34,8 @@ class ConsoleLoggers(
             return
         }
 
-        val loc = event.boss.entity?.location
-        val location = "${loc?.world?.name}: ${loc?.x}, ${loc?.y}, ${loc?.z}"
+        val loc = event.boss.entity.location
+        val location = "${loc.world?.name}: ${loc.x}, ${loc.y}, ${loc.z}"
 
         plugin.logger.info("&a${event.boss.boss.id}&r was killed by &a${event.killer?.name}&r at &a$location")
     }
@@ -48,8 +48,8 @@ class ConsoleLoggers(
         if (!plugin.configYml.getBool("log-spawn-kill")) {
             return
         }
-        val loc = event.boss.entity?.location
-        val location = "${loc?.world?.name}: ${loc?.x}, ${loc?.y}, ${loc?.z}"
+        val loc = event.boss.entity.location
+        val location = "${loc.world?.name}: ${loc.x}, ${loc.y}, ${loc.z}"
 
         plugin.logger.info("&a${event.boss.boss.id}&r despawned at &a$location")
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/lifecycle/LifecycleHandlers.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/lifecycle/LifecycleHandlers.kt
@@ -28,7 +28,7 @@ class LifecycleHandlers : Listener {
         priority = EventPriority.MONITOR
     )
     fun handle(event: BossKillEvent) {
-        val entity = event.boss.entity ?: return
+        val entity = event.boss.entity
 
         event.boss.boss.handleLifecycle(BossLifecycle.KILL, entity.location, entity)
     }
@@ -38,7 +38,7 @@ class LifecycleHandlers : Listener {
         priority = EventPriority.MONITOR
     )
     fun handle(event: BossDespawnEvent) {
-        val entity = event.boss.entity ?: return
+        val entity = event.boss.entity
 
         event.boss.boss.handleLifecycle(BossLifecycle.DESPAWN, entity.location, entity)
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/BossBarTicker.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/BossBarTicker.kt
@@ -12,7 +12,7 @@ class BossBarTicker(
     private val bar: BossBar
 ) : BossTicker {
     override fun tick(boss: LivingEcoBoss, tick: Int) {
-        val entity = boss.entity ?: return
+        val entity = boss.entity
 
         bar.name(entity.customName!!.toComponent())
         bar.progress((entity.health / entity.getAttribute(Attribute.GENERIC_MAX_HEALTH)!!.value).toFloat())

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/ChunkTicker.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/ChunkTicker.kt
@@ -1,0 +1,23 @@
+package com.willfp.ecobosses.tick
+
+import com.willfp.ecobosses.bosses.LivingEcoBoss
+
+class ChunkTicker() : BossTicker {
+
+    override fun tick(boss: LivingEcoBoss, tick: Int) {
+        val currentChunk = boss.chunk
+
+        if (tick % 10 != 0) {
+            return
+        }
+
+        if (currentChunk.isLoaded && currentChunk.isForceLoaded) {
+            return;
+        }
+
+        currentChunk.load()
+        currentChunk.isForceLoaded = true
+        boss.forceLoadedChunks.add(currentChunk)
+    }
+
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/DisplayNameTicker.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/DisplayNameTicker.kt
@@ -7,7 +7,7 @@ import kotlin.math.ceil
 
 class DisplayNameTicker : BossTicker {
     override fun tick(boss: LivingEcoBoss, tick: Int) {
-        val entity = boss.entity ?: return
+        val entity = boss.entity
 
         val timeLeft = ceil(
             (boss.deathTime - System.currentTimeMillis()) / 1000.0

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/LifespanTicker.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/LifespanTicker.kt
@@ -16,7 +16,7 @@ class LifespanTicker : BossTicker {
             boss.remove()
             boss.boss.handleLifecycle(
                 BossLifecycle.DESPAWN,
-                boss.entity?.location ?: return,
+                boss.entity.location,
                 boss.entity
             )
         }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/TargetTicker.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/TargetTicker.kt
@@ -4,7 +4,7 @@ import com.willfp.ecobosses.bosses.LivingEcoBoss
 
 class TargetTicker : BossTicker {
     override fun tick(boss: LivingEcoBoss, tick: Int) {
-        val entity = boss.entity ?: return
+        val entity = boss.entity
 
         if (tick % 10 != 0) {
             return

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/TeleportHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobosses/tick/TeleportHandler.kt
@@ -7,7 +7,7 @@ import org.bukkit.block.BlockFace
 
 class TeleportHandler : BossTicker {
     override fun tick(boss: LivingEcoBoss, tick: Int) {
-        val entity = boss.entity ?: return
+        val entity = boss.entity
         if (!boss.boss.canTeleport) {
             return
         }


### PR DESCRIPTION
Earlier it was failing on `Bukkit.getEntity` even is chunk was forceloaded. `mob` variable is already entity, so we are passing it to `LivingEcoBoss` instead of uuid which makes entity never null.

Added ChunkTicker which forceloads chunks where boss is located, afterwards all are set to false and cleared.

Demonstration video: https://streamable.com/qp7wk3


Probably fixes: #39 #33 #31 #30 
