### PR TITLE
feat: Spawner System

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:7.4.0")
+        compileOnly("com.willfp:eco:7.4.1")
         compileOnly("org.jetbrains:annotations:26.0.2")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.2.3")

--- a/eco-core/core-plugin/build.gradle.kts
+++ b/eco-core/core-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ group = "com.willfp"
 version = rootProject.version
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.20.2-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
     compileOnly("io.github.arcaneplugins:levelledmobs-plugin:4.0.2")
     compileOnly("me.libraryaddict.disguises:libsdisguises:11.0.14")
     implementation("com.willfp:ModelEngineBridge:1.3.0")

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/EcoMobsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/EcoMobsPlugin.kt
@@ -9,11 +9,13 @@ import com.willfp.ecomobs.category.MobCategories
 import com.willfp.ecomobs.category.spawning.spawnpoints.SpawnPointGenerator
 import com.willfp.ecomobs.commands.CommandEcoMobs
 import com.willfp.ecomobs.display.SpawnEggDisplay
+import com.willfp.ecomobs.display.SpawnerItemDisplay
 import com.willfp.ecomobs.goals.entity.EntityGoalRandomTeleport
 import com.willfp.ecomobs.handler.DamageModifierHandler
 import com.willfp.ecomobs.handler.MountHandler
 import com.willfp.ecomobs.handler.SpawnEggHandler
 import com.willfp.ecomobs.handler.SpawnTotemHandler
+import com.willfp.ecomobs.handler.SpawnerHandler
 import com.willfp.ecomobs.handler.VanillaCompatibilityHandlers
 import com.willfp.ecomobs.integrations.bettermodel.IntegrationBetterModel
 import com.willfp.ecomobs.integrations.levelledmobs.IntegrationLevelledMobs
@@ -22,6 +24,8 @@ import com.willfp.ecomobs.integrations.modelengine.IntegrationModelEngine
 import com.willfp.ecomobs.mob.EcoMobs
 import com.willfp.ecomobs.mob.damage.TopDamagerHandler
 import com.willfp.ecomobs.mob.impl.ecoMob
+import com.willfp.ecomobs.spawner.SpawnerAnimations
+import com.willfp.ecomobs.spawner.SpawnerDisplay
 import com.willfp.libreforge.EntityProvidedHolder
 import com.willfp.libreforge.loader.LibreforgePlugin
 import com.willfp.libreforge.loader.configs.ConfigCategory
@@ -59,6 +63,11 @@ class EcoMobsPlugin : LibreforgePlugin() {
         )
     }
 
+    override fun handleReload() {
+        SpawnerAnimations.reload()
+        SpawnerDisplay.start()
+    }
+
     override fun loadListeners(): List<Listener> {
         return listOf(
             DamageModifierHandler,
@@ -67,13 +76,13 @@ class EcoMobsPlugin : LibreforgePlugin() {
             DiscoverRecipeListener,
             SpawnEggHandler,
             SpawnTotemHandler,
-            topDamagerHandler
+            topDamagerHandler,
+            SpawnerHandler
         )
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun createDisplayModule(): DisplayModule {
-        return SpawnEggDisplay
+    override fun loadDisplayModules(): List<DisplayModule> {
+        return listOf(SpawnEggDisplay, SpawnerItemDisplay)
     }
 
     override fun loadIntegrationLoaders(): List<IntegrationLoader> {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandEcoMobs.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandEcoMobs.kt
@@ -21,5 +21,6 @@ object CommandEcoMobs : PluginCommand(
         this.addSubcommand(CommandReload)
             .addSubcommand(CommandSpawn)
             .addSubcommand(CommandGive)
+            .addSubcommand(CommandSpawner)
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawner.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawner.kt
@@ -1,0 +1,18 @@
+package com.willfp.ecomobs.commands
+
+import com.willfp.eco.core.command.impl.Subcommand
+import com.willfp.ecomobs.plugin
+import org.bukkit.command.CommandSender
+
+object CommandSpawner : Subcommand(
+    plugin, "spawner", "ecomobs.command.spawner", false
+) {
+    init {
+        addSubcommand(CommandSpawnerGive)
+        addSubcommand(CommandSpawnerModify)
+    }
+
+    override fun onExecute(sender: CommandSender, args: List<String>) {
+        sender.sendMessage(plugin.langYml.getMessage("invalid-command"))
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerGive.kt
@@ -5,6 +5,7 @@ import com.willfp.eco.core.drops.DropQueue
 import com.willfp.eco.core.fast.fast
 import com.willfp.ecomobs.mob.EcoMobs
 import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.SpawnerItemModifier
 import com.willfp.ecomobs.spawner.spawnerDelayMax
 import com.willfp.ecomobs.spawner.spawnerDelayMin
 import com.willfp.ecomobs.spawner.spawnerMaxNearby
@@ -49,6 +50,8 @@ object CommandSpawnerGive : Subcommand(
         }
 
         val amount = args.getOrNull(2)?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+        val tailStart = if (args.getOrNull(2)?.toIntOrNull() != null) 3 else 2
+        val tail = args.drop(tailStart)
 
         val item = ItemStack(Material.SPAWNER, amount)
         val fis = item.fast()
@@ -60,6 +63,32 @@ object CommandSpawnerGive : Subcommand(
         fis.spawnerPlayerRange = 16
         fis.spawnerMaxNearby = 6
         fis.spawnerPickup = "deny"
+
+        var i = 0
+        while (i < tail.size) {
+            val attribute = tail[i].lowercase()
+            if (attribute == "mob" || attribute !in SpawnerItemModifier.ATTRIBUTES) {
+                sender.sendMessage(plugin.langYml.getMessage("invalid-command"))
+                return
+            }
+            if (!sender.hasPermission("ecomobs.command.spawner.modify.$attribute")) {
+                sender.sendMessage(plugin.langYml.getMessage("no-permission"))
+                return
+            }
+            val value = SpawnerItemModifier.valueCount(attribute)
+            val valueArgs = tail.subList(i + 1, minOf(i + 1 + value, tail.size))
+            if (valueArgs.size < value) {
+                sender.sendMessage(plugin.langYml.getMessage("invalid-command"))
+                return
+            }
+            if (!SpawnerItemModifier.apply(fis, attribute, valueArgs)) {
+                sender.sendMessage(
+                    plugin.langYml.getMessage("spawner-invalid-value").replace("%attribute%", attribute)
+                )
+                return
+            }
+            i += 1 + value
+        }
 
         DropQueue(recipient)
             .addItem(fis.unwrap())
@@ -87,7 +116,51 @@ object CommandSpawnerGive : Subcommand(
             )
 
         if (args.size == 3)
-            StringUtil.copyPartialMatches(args[2], listOf("1", "2", "3", "4", "5"), completions)
+            StringUtil.copyPartialMatches(
+                args[2],
+                listOf("1", "2", "3", "4", "5") + SpawnerItemModifier.ATTRIBUTES
+                    .filter { it != "mob" && sender.hasPermission("ecomobs.command.spawner.modify.$it") },
+                completions
+            )
+
+        if (args.size >= 4) {
+            val tailStart = if (args[2].toIntOrNull() != null) 3 else 2
+            val tail = args.drop(tailStart)
+            val cursorIndex = tail.size - 1
+            val usedAttributes = mutableSetOf<String>()
+
+            var i = 0
+            while (i <= cursorIndex) {
+                val token = tail[i].lowercase()
+                if (i == cursorIndex) {
+                    StringUtil.copyPartialMatches(
+                        token,
+                        SpawnerItemModifier.ATTRIBUTES.filter { attr ->
+                            attr != "mob" && attr !in usedAttributes &&
+                                sender.hasPermission("ecomobs.command.spawner.modify.$attr")
+                        },
+                        completions
+                    )
+                    break
+                }
+                if (token !in SpawnerItemModifier.ATTRIBUTES || token == "mob") {
+                    i++
+                    continue
+                }
+                val value = SpawnerItemModifier.valueCount(token)
+                usedAttributes.add(token)
+                if (i + value >= cursorIndex) {
+                    val valueIndex = cursorIndex - i - 1
+                    StringUtil.copyPartialMatches(
+                        tail[cursorIndex],
+                        SpawnerItemModifier.tabComplete(token, valueIndex),
+                        completions
+                    )
+                    break
+                }
+                i += 1 + value
+            }
+        }
 
         completions.sort()
         return completions

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerGive.kt
@@ -1,0 +1,95 @@
+package com.willfp.ecomobs.commands
+
+import com.willfp.eco.core.command.impl.Subcommand
+import com.willfp.eco.core.drops.DropQueue
+import com.willfp.eco.core.fast.fast
+import com.willfp.ecomobs.mob.EcoMobs
+import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.spawnerDelayMax
+import com.willfp.ecomobs.spawner.spawnerDelayMin
+import com.willfp.ecomobs.spawner.spawnerMaxNearby
+import com.willfp.ecomobs.spawner.spawnerMob
+import com.willfp.ecomobs.spawner.spawnerPickup
+import com.willfp.ecomobs.spawner.spawnerPlayerRange
+import com.willfp.ecomobs.spawner.spawnerSpawnCount
+import com.willfp.ecomobs.spawner.spawnerSpawnRange
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.EntityType
+import org.bukkit.inventory.ItemStack
+import org.bukkit.util.StringUtil
+
+object CommandSpawnerGive : Subcommand(
+    plugin, "give", "ecomobs.command.spawner.give", false
+) {
+    override fun onExecute(sender: CommandSender, args: List<String>) {
+        if (args.isEmpty()) {
+            sender.sendMessage(plugin.langYml.getMessage("needs-player"))
+            return
+        }
+        if (args.size == 1) {
+            sender.sendMessage(plugin.langYml.getMessage("spawner-invalid-mob"))
+            return
+        }
+
+        val recipient = Bukkit.getPlayer(args[0]) ?: run {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
+            return
+        }
+
+        val mobId = args[1]
+        val validMob = EcoMobs[mobId] != null || runCatching {
+            EntityType.valueOf(mobId.uppercase())
+        }.isSuccess
+
+        if (!validMob) {
+            sender.sendMessage(plugin.langYml.getMessage("spawner-invalid-mob"))
+            return
+        }
+
+        val amount = args.getOrNull(2)?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+
+        val item = ItemStack(Material.SPAWNER, amount)
+        val fis = item.fast()
+        fis.spawnerMob = mobId
+        fis.spawnerDelayMin = 200
+        fis.spawnerDelayMax = 800
+        fis.spawnerSpawnCount = 4
+        fis.spawnerSpawnRange = 4
+        fis.spawnerPlayerRange = 16
+        fis.spawnerMaxNearby = 6
+        fis.spawnerPickup = "deny"
+
+        DropQueue(recipient)
+            .addItem(fis.unwrap())
+            .forceTelekinesis()
+            .push()
+
+        sender.sendMessage(
+            plugin.langYml.getMessage("spawner-give")
+                .replace("%player%", recipient.name)
+                .replace("%mob%", mobId)
+        )
+    }
+
+    override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
+        val completions = mutableListOf<String>()
+
+        if (args.size == 1)
+            StringUtil.copyPartialMatches(args[0], Bukkit.getOnlinePlayers().map { it.name }, completions)
+
+        if (args.size == 2)
+            StringUtil.copyPartialMatches(
+                args[1],
+                EcoMobs.values().map { it.id } + EntityType.entries.map { it.name.lowercase() },
+                completions
+            )
+
+        if (args.size == 3)
+            StringUtil.copyPartialMatches(args[2], listOf("1", "2", "3", "4", "5"), completions)
+
+        completions.sort()
+        return completions
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
@@ -1,0 +1,206 @@
+package com.willfp.ecomobs.commands
+
+import com.willfp.eco.core.command.impl.Subcommand
+import com.willfp.eco.core.fast.fast
+import com.willfp.ecomobs.mob.EcoMobs
+import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.PlacedSpawner
+import com.willfp.ecomobs.spawner.PlacedSpawners
+import com.willfp.ecomobs.spawner.SpawnerAnimations
+import com.willfp.ecomobs.spawner.applyVanillaSettings
+import com.willfp.ecomobs.spawner.isCustomSpawner
+import com.willfp.ecomobs.spawner.spawnerDelayMax
+import com.willfp.ecomobs.spawner.spawnerDelayMin
+import com.willfp.ecomobs.spawner.spawnerMaxNearby
+import com.willfp.ecomobs.spawner.spawnerMob
+import com.willfp.ecomobs.spawner.spawnerParticleAnim
+import com.willfp.ecomobs.spawner.spawnerPickup
+import com.willfp.ecomobs.spawner.spawnerPlayerRange
+import com.willfp.ecomobs.spawner.spawnerSpawnCount
+import com.willfp.ecomobs.spawner.spawnerSpawnRange
+import org.bukkit.Material
+import org.bukkit.block.CreatureSpawner
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.EntityType
+import org.bukkit.entity.Player
+import org.bukkit.util.StringUtil
+
+private val ATTRIBUTES = listOf("mob", "delay", "radius", "player-radius", "count", "max-count", "pickup", "particle")
+private val PICKUP_VALUES = listOf("allow", "silk_touch", "deny")
+
+object CommandSpawnerModify : Subcommand(
+    plugin, "modify", "ecomobs.command.spawner.modify", true
+) {
+    override fun onExecute(sender: CommandSender, args: List<String>) {
+        val player = sender as Player
+
+        if (args.isEmpty()) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-command"))
+            return
+        }
+
+        val attribute = args[0].lowercase()
+
+        if (!player.hasPermission("ecomobs.command.spawner.modify.$attribute")) {
+            sender.sendMessage(plugin.langYml.getMessage("no-permission"))
+            return
+        }
+
+        val heldFis = player.inventory.itemInMainHand.fast()
+        val isHeld = heldFis.isCustomSpawner
+
+        var targetState: CreatureSpawner? = null
+        var targetLocation = player.location
+
+        if (!isHeld) {
+            val targetBlock = player.getTargetBlockExact(5)
+            if (targetBlock == null || targetBlock.type != Material.SPAWNER) {
+                sender.sendMessage(plugin.langYml.getMessage("spawner-no-target"))
+                return
+            }
+            val state = targetBlock.state as? CreatureSpawner
+            if (state == null || !state.isCustomSpawner) {
+                sender.sendMessage(plugin.langYml.getMessage("spawner-no-target"))
+                return
+            }
+            targetState = state
+            targetLocation = targetBlock.location
+        }
+
+        fun invalidValue() = sender.sendMessage(
+            plugin.langYml.getMessage("spawner-invalid-value").replace("%attribute%", attribute)
+        )
+
+        fun applyBlock() {
+            targetState!!.applyVanillaSettings()
+            targetState.update()
+        }
+
+        when (attribute) {
+            "mob" -> {
+                val mobId = args.getOrNull(1) ?: return invalidValue()
+                val valid = EcoMobs[mobId] != null || runCatching {
+                    EntityType.valueOf(mobId.uppercase())
+                }.isSuccess
+                if (!valid) {
+                    sender.sendMessage(plugin.langYml.getMessage("spawner-invalid-mob")); return
+                }
+                if (isHeld) heldFis.spawnerMob = mobId
+                else {
+                    targetState!!.spawnerMob = mobId; targetState.update()
+                }
+            }
+
+            "delay" -> {
+                val min = args.getOrNull(1)?.toIntOrNull()
+                val max = args.getOrNull(2)?.toIntOrNull()
+                if (min == null || max == null || min < 0 || min > max) return invalidValue()
+                if (isHeld) {
+                    heldFis.spawnerDelayMin = min; heldFis.spawnerDelayMax = max
+                } else {
+                    targetState!!.spawnerDelayMin = min; targetState.spawnerDelayMax = max; applyBlock()
+                }
+            }
+
+            "radius" -> {
+                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
+                if (isHeld) heldFis.spawnerSpawnRange = value
+                else {
+                    targetState!!.spawnerSpawnRange = value; applyBlock()
+                }
+            }
+
+            "player-radius" -> {
+                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
+                if (isHeld) heldFis.spawnerPlayerRange = value
+                else {
+                    targetState!!.spawnerPlayerRange = value; applyBlock()
+                }
+            }
+
+            "count" -> {
+                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
+                if (isHeld) heldFis.spawnerSpawnCount = value
+                else {
+                    targetState!!.spawnerSpawnCount = value; applyBlock()
+                }
+            }
+
+            "max-count" -> {
+                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
+                if (isHeld) heldFis.spawnerMaxNearby = value
+                else {
+                    targetState!!.spawnerMaxNearby = value; applyBlock()
+                }
+            }
+
+            "pickup" -> {
+                val raw = args.getOrNull(1)?.lowercase() ?: return invalidValue()
+                val value = if (raw == "silk-touch") "silk_touch" else raw
+                if (value !in PICKUP_VALUES) return invalidValue()
+                if (isHeld) heldFis.spawnerPickup = value
+                else {
+                    targetState!!.spawnerPickup = value; targetState.update()
+                }
+            }
+
+            "particle" -> {
+                val value = args.getOrNull(1)?.lowercase() ?: return invalidValue()
+                if (value != "none" && SpawnerAnimations[value] == null) return invalidValue()
+                val stored = if (value == "none") null else value
+                if (isHeld) heldFis.spawnerParticleAnim = stored
+                else {
+                    targetState!!.spawnerParticleAnim = stored
+                    targetState.update()
+                    PlacedSpawners.set(targetLocation, PlacedSpawner(targetLocation, stored))
+                }
+            }
+
+            else -> {
+                sender.sendMessage(plugin.langYml.getMessage("invalid-command")); return
+            }
+        }
+
+        if (isHeld) player.updateInventory()
+
+        sender.sendMessage(
+            plugin.langYml.getMessage("spawner-modified")
+                .replace("%attribute%", attribute)
+                .replace("%value%", args.drop(1).joinToString(" "))
+        )
+    }
+
+    override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
+        val completions = mutableListOf<String>()
+
+        if (args.size == 1)
+            StringUtil.copyPartialMatches(
+                args[0],
+                ATTRIBUTES.filter { sender.hasPermission("ecomobs.command.spawner.modify.$it") },
+                completions
+            )
+
+        if (args.size == 2) {
+            when (args[0].lowercase()) {
+                "mob" -> StringUtil.copyPartialMatches(
+                    args[1],
+                    EcoMobs.values().map { it.id } + EntityType.entries.map { it.name.lowercase() },
+                    completions
+                )
+
+                "pickup" -> StringUtil.copyPartialMatches(args[1], PICKUP_VALUES, completions)
+                "particle" -> StringUtil.copyPartialMatches(
+                    args[1], listOf("none") + SpawnerAnimations.keys(), completions
+                )
+
+                else -> StringUtil.copyPartialMatches(args[1], listOf("1", "4", "8", "16", "200"), completions)
+            }
+        }
+
+        if (args.size == 3 && args[0].lowercase() == "delay")
+            StringUtil.copyPartialMatches(args[2], listOf("200", "400", "800"), completions)
+
+        completions.sort()
+        return completions
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
@@ -17,6 +17,7 @@ import com.willfp.ecomobs.spawner.spawnerParticleAnim
 import com.willfp.ecomobs.spawner.spawnerPickup
 import com.willfp.ecomobs.spawner.spawnerPlayerRange
 import com.willfp.ecomobs.spawner.spawnerSpawnCount
+import com.willfp.ecomobs.spawner.resolveEntityType
 import com.willfp.ecomobs.spawner.spawnerSpawnRange
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
@@ -87,7 +88,9 @@ object CommandSpawnerModify : Subcommand(
                 }
                 if (isHeld) heldFis.spawnerMob = mobId
                 else {
-                    targetState!!.spawnerMob = mobId; targetState.update()
+                    targetState!!.spawnerMob = mobId
+                    resolveEntityType(mobId)?.let { targetState.spawnedType = it }
+                    targetState.update()
                 }
             }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
@@ -60,7 +60,7 @@ object CommandSpawnerModify : Subcommand(
                 return
             }
             val state = targetBlock.state as? CreatureSpawner
-            if (state == null || !state.isCustomSpawner) {
+            if (state == null) {
                 sender.sendMessage(plugin.langYml.getMessage("spawner-no-target"))
                 return
             }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/commands/CommandSpawnerModify.kt
@@ -4,9 +4,11 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.core.fast.fast
 import com.willfp.ecomobs.mob.EcoMobs
 import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.PICKUP_VALUES
 import com.willfp.ecomobs.spawner.PlacedSpawner
 import com.willfp.ecomobs.spawner.PlacedSpawners
 import com.willfp.ecomobs.spawner.SpawnerAnimations
+import com.willfp.ecomobs.spawner.SpawnerItemModifier
 import com.willfp.ecomobs.spawner.applyVanillaSettings
 import com.willfp.ecomobs.spawner.isCustomSpawner
 import com.willfp.ecomobs.spawner.spawnerDelayMax
@@ -18,6 +20,7 @@ import com.willfp.ecomobs.spawner.spawnerPickup
 import com.willfp.ecomobs.spawner.spawnerPlayerRange
 import com.willfp.ecomobs.spawner.spawnerSpawnCount
 import com.willfp.ecomobs.spawner.resolveEntityType
+import com.willfp.ecomobs.spawner.spawnerExplosionProof
 import com.willfp.ecomobs.spawner.spawnerSpawnRange
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
@@ -25,9 +28,6 @@ import org.bukkit.command.CommandSender
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.Player
 import org.bukkit.util.StringUtil
-
-private val ATTRIBUTES = listOf("mob", "delay", "radius", "player-radius", "count", "max-count", "pickup", "particle")
-private val PICKUP_VALUES = listOf("allow", "silk_touch", "deny")
 
 object CommandSpawnerModify : Subcommand(
     plugin, "modify", "ecomobs.command.spawner.modify", true
@@ -77,94 +77,86 @@ object CommandSpawnerModify : Subcommand(
             targetState.update()
         }
 
-        when (attribute) {
-            "mob" -> {
-                val mobId = args.getOrNull(1) ?: return invalidValue()
-                val valid = EcoMobs[mobId] != null || runCatching {
-                    EntityType.valueOf(mobId.uppercase())
-                }.isSuccess
-                if (!valid) {
-                    sender.sendMessage(plugin.langYml.getMessage("spawner-invalid-mob")); return
+        if (isHeld) {
+            if (!SpawnerItemModifier.apply(heldFis, attribute, args.drop(1))) {
+                if (attribute !in SpawnerItemModifier.ATTRIBUTES) {
+                    sender.sendMessage(plugin.langYml.getMessage("invalid-command"))
+                } else {
+                    invalidValue()
                 }
-                if (isHeld) heldFis.spawnerMob = mobId
-                else {
+                return
+            }
+            player.updateInventory()
+        } else {
+            when (attribute) {
+                "mob" -> {
+                    val mobId = args.getOrNull(1) ?: return invalidValue()
+                    val valid = EcoMobs[mobId] != null || runCatching {
+                        EntityType.valueOf(mobId.uppercase())
+                    }.isSuccess
+                    if (!valid) {
+                        sender.sendMessage(plugin.langYml.getMessage("spawner-invalid-mob")); return
+                    }
                     targetState!!.spawnerMob = mobId
                     resolveEntityType(mobId)?.let { targetState.spawnedType = it }
                     targetState.update()
                 }
-            }
 
-            "delay" -> {
-                val min = args.getOrNull(1)?.toIntOrNull()
-                val max = args.getOrNull(2)?.toIntOrNull()
-                if (min == null || max == null || min < 0 || min > max) return invalidValue()
-                if (isHeld) {
-                    heldFis.spawnerDelayMin = min; heldFis.spawnerDelayMax = max
-                } else {
+                "delay" -> {
+                    val min = args.getOrNull(1)?.toIntOrNull()
+                    val max = args.getOrNull(2)?.toIntOrNull()
+                    if (min == null || max == null || min < 0 || min > max) return invalidValue()
                     targetState!!.spawnerDelayMin = min; targetState.spawnerDelayMax = max; applyBlock()
                 }
-            }
 
-            "radius" -> {
-                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
-                if (isHeld) heldFis.spawnerSpawnRange = value
-                else {
+                "radius" -> {
+                    val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
                     targetState!!.spawnerSpawnRange = value; applyBlock()
                 }
-            }
 
-            "player-radius" -> {
-                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
-                if (isHeld) heldFis.spawnerPlayerRange = value
-                else {
+                "player-radius" -> {
+                    val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
                     targetState!!.spawnerPlayerRange = value; applyBlock()
                 }
-            }
 
-            "count" -> {
-                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
-                if (isHeld) heldFis.spawnerSpawnCount = value
-                else {
+                "count" -> {
+                    val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
                     targetState!!.spawnerSpawnCount = value; applyBlock()
                 }
-            }
 
-            "max-count" -> {
-                val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
-                if (isHeld) heldFis.spawnerMaxNearby = value
-                else {
+                "max-nearby" -> {
+                    val value = args.getOrNull(1)?.toIntOrNull()?.takeIf { it >= 1 } ?: return invalidValue()
                     targetState!!.spawnerMaxNearby = value; applyBlock()
                 }
-            }
 
-            "pickup" -> {
-                val raw = args.getOrNull(1)?.lowercase() ?: return invalidValue()
-                val value = if (raw == "silk-touch") "silk_touch" else raw
-                if (value !in PICKUP_VALUES) return invalidValue()
-                if (isHeld) heldFis.spawnerPickup = value
-                else {
+                "pickup" -> {
+                    val raw = args.getOrNull(1)?.lowercase() ?: return invalidValue()
+                    val value = if (raw == "silk-touch") "silk_touch" else raw
+                    if (value !in PICKUP_VALUES) return invalidValue()
                     targetState!!.spawnerPickup = value; targetState.update()
                 }
-            }
 
-            "particle" -> {
-                val value = args.getOrNull(1)?.lowercase() ?: return invalidValue()
-                if (value != "none" && SpawnerAnimations[value] == null) return invalidValue()
-                val stored = if (value == "none") null else value
-                if (isHeld) heldFis.spawnerParticleAnim = stored
-                else {
+                "particle" -> {
+                    val value = args.getOrNull(1)?.lowercase() ?: return invalidValue()
+                    if (value != "none" && SpawnerAnimations[value] == null) return invalidValue()
+                    val stored = if (value == "none") null else value
                     targetState!!.spawnerParticleAnim = stored
                     targetState.update()
                     PlacedSpawners.set(targetLocation, PlacedSpawner(targetLocation, stored))
                 }
-            }
 
-            else -> {
-                sender.sendMessage(plugin.langYml.getMessage("invalid-command")); return
+                "explosion-proof" -> {
+                    val value = args.getOrNull(1)?.lowercase() ?: return invalidValue()
+                    if (value != "true" && value != "false") return invalidValue()
+                    targetState!!.spawnerExplosionProof = value == "true"
+                    targetState.update()
+                }
+
+                else -> {
+                    sender.sendMessage(plugin.langYml.getMessage("invalid-command")); return
+                }
             }
         }
-
-        if (isHeld) player.updateInventory()
 
         sender.sendMessage(
             plugin.langYml.getMessage("spawner-modified")
@@ -176,32 +168,29 @@ object CommandSpawnerModify : Subcommand(
     override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
         val completions = mutableListOf<String>()
 
-        if (args.size == 1)
+        if (args.size == 1) {
             StringUtil.copyPartialMatches(
                 args[0],
-                ATTRIBUTES.filter { sender.hasPermission("ecomobs.command.spawner.modify.$it") },
+                SpawnerItemModifier.ATTRIBUTES.filter { sender.hasPermission("ecomobs.command.spawner.modify.$it") },
                 completions
             )
-
-        if (args.size == 2) {
-            when (args[0].lowercase()) {
-                "mob" -> StringUtil.copyPartialMatches(
-                    args[1],
-                    EcoMobs.values().map { it.id } + EntityType.entries.map { it.name.lowercase() },
-                    completions
-                )
-
-                "pickup" -> StringUtil.copyPartialMatches(args[1], PICKUP_VALUES, completions)
-                "particle" -> StringUtil.copyPartialMatches(
-                    args[1], listOf("none") + SpawnerAnimations.keys(), completions
-                )
-
-                else -> StringUtil.copyPartialMatches(args[1], listOf("1", "4", "8", "16", "200"), completions)
-            }
         }
 
-        if (args.size == 3 && args[0].lowercase() == "delay")
-            StringUtil.copyPartialMatches(args[2], listOf("200", "400", "800"), completions)
+        if (args.size == 2) {
+            StringUtil.copyPartialMatches(
+                args[1],
+                SpawnerItemModifier.tabComplete(args[0].lowercase(), 0),
+                completions
+            )
+        }
+
+        if (args.size == 3 && args[0].lowercase() == "delay") {
+            StringUtil.copyPartialMatches(
+                args[2],
+                SpawnerItemModifier.tabComplete("delay", 1),
+                completions
+            )
+        }
 
         completions.sort()
         return completions

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
@@ -4,6 +4,8 @@ import com.willfp.eco.core.display.Display
 import com.willfp.eco.core.display.DisplayModule
 import com.willfp.eco.core.display.DisplayPriority
 import com.willfp.eco.core.fast.fast
+import com.willfp.eco.core.placeholder.context.placeholderContext
+import com.willfp.eco.util.formatEco
 import com.willfp.ecomobs.plugin
 import com.willfp.ecomobs.spawner.isCustomSpawner
 import com.willfp.ecomobs.spawner.spawnerDelayMax
@@ -24,16 +26,22 @@ object SpawnerItemDisplay : DisplayModule(plugin, DisplayPriority.LOW) {
         val fis = itemStack.fast()
         if (!fis.isCustomSpawner) return
 
-        val lore = listOf(
-            "${Display.PREFIX}&8Mob: &f${fis.spawnerMob}",
-            "${Display.PREFIX}&8Delay: &f${fis.spawnerDelayMin}-${fis.spawnerDelayMax} ticks",
-            "${Display.PREFIX}&8Radius: &f${fis.spawnerSpawnRange}",
-            "${Display.PREFIX}&8Player Range: &f${fis.spawnerPlayerRange}",
-            "${Display.PREFIX}&8Count: &f${fis.spawnerSpawnCount}",
-            "${Display.PREFIX}&8Max Nearby: &f${fis.spawnerMaxNearby}",
-            "${Display.PREFIX}&8Pickup: &f${fis.spawnerPickup}",
-            "${Display.PREFIX}&8Particle: &f${fis.spawnerParticleAnim ?: "none"}"
-        )
+        val context = placeholderContext(player = player, item = itemStack)
+
+        val lore = plugin.configYml.getStrings("spawner-display.lore")
+            .map { line ->
+                line
+                    .replace("%mob%", fis.spawnerMob ?: "")
+                    .replace("%delay_min%", fis.spawnerDelayMin.toString())
+                    .replace("%delay_max%", fis.spawnerDelayMax.toString())
+                    .replace("%radius%", fis.spawnerSpawnRange.toString())
+                    .replace("%player_range%", fis.spawnerPlayerRange.toString())
+                    .replace("%count%", fis.spawnerSpawnCount.toString())
+                    .replace("%max_nearby%", fis.spawnerMaxNearby.toString())
+                    .replace("%pickup%", fis.spawnerPickup)
+                    .replace("%particle%", fis.spawnerParticleAnim ?: "none")
+            }
+            .map { Display.PREFIX + it.formatEco(context) }
 
         fis.lore = lore + fis.lore
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
@@ -7,6 +7,7 @@ import com.willfp.eco.core.fast.FastItemStack
 import com.willfp.eco.core.fast.fast
 import com.willfp.eco.core.placeholder.context.placeholderContext
 import com.willfp.eco.util.formatEco
+import com.willfp.eco.util.titlecase
 import com.willfp.ecomobs.plugin
 import com.willfp.ecomobs.spawner.isCustomSpawner
 import com.willfp.ecomobs.spawner.spawnerDelayMax
@@ -25,6 +26,7 @@ import org.bukkit.inventory.ItemStack
 private fun FastItemStack.applySpawnerPlaceholders(text: String): String =
     text
         .replace("%mob%", spawnerMob ?: "")
+        .replace("%mob_formatted%", spawnerMob?.replace("_", " ")?.titlecase() ?: "")
         .replace("%delay_min%", spawnerDelayMin.toString())
         .replace("%delay_max%", spawnerDelayMax.toString())
         .replace("%radius%", spawnerSpawnRange.toString())

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
@@ -14,6 +14,7 @@ import com.willfp.ecomobs.spawner.spawnerDelayMin
 import com.willfp.ecomobs.spawner.spawnerMaxNearby
 import com.willfp.ecomobs.spawner.spawnerMob
 import com.willfp.ecomobs.spawner.spawnerParticleAnim
+import com.willfp.ecomobs.spawner.spawnerExplosionProof
 import com.willfp.ecomobs.spawner.spawnerPickup
 import com.willfp.ecomobs.spawner.spawnerPlayerRange
 import com.willfp.ecomobs.spawner.spawnerSpawnCount
@@ -32,6 +33,7 @@ private fun FastItemStack.applySpawnerPlaceholders(text: String): String =
         .replace("%max_nearby%", spawnerMaxNearby.toString())
         .replace("%pickup%", spawnerPickup)
         .replace("%particle%", spawnerParticleAnim ?: "none")
+        .replace("%explosion_proof%", spawnerExplosionProof.toString())
 
 object SpawnerItemDisplay : DisplayModule(plugin, DisplayPriority.LOW) {
     override fun display(itemStack: ItemStack, player: Player?, vararg args: Any) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
@@ -3,6 +3,7 @@ package com.willfp.ecomobs.display
 import com.willfp.eco.core.display.Display
 import com.willfp.eco.core.display.DisplayModule
 import com.willfp.eco.core.display.DisplayPriority
+import com.willfp.eco.core.fast.FastItemStack
 import com.willfp.eco.core.fast.fast
 import com.willfp.eco.core.placeholder.context.placeholderContext
 import com.willfp.eco.util.formatEco
@@ -20,6 +21,18 @@ import com.willfp.ecomobs.spawner.spawnerSpawnRange
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 
+private fun FastItemStack.applySpawnerPlaceholders(text: String): String =
+    text
+        .replace("%mob%", spawnerMob ?: "")
+        .replace("%delay_min%", spawnerDelayMin.toString())
+        .replace("%delay_max%", spawnerDelayMax.toString())
+        .replace("%radius%", spawnerSpawnRange.toString())
+        .replace("%player_range%", spawnerPlayerRange.toString())
+        .replace("%count%", spawnerSpawnCount.toString())
+        .replace("%max_nearby%", spawnerMaxNearby.toString())
+        .replace("%pickup%", spawnerPickup)
+        .replace("%particle%", spawnerParticleAnim ?: "none")
+
 object SpawnerItemDisplay : DisplayModule(plugin, DisplayPriority.LOW) {
     override fun display(itemStack: ItemStack, player: Player?, vararg args: Any) {
         if (player == null) return
@@ -28,20 +41,13 @@ object SpawnerItemDisplay : DisplayModule(plugin, DisplayPriority.LOW) {
 
         val context = placeholderContext(player = player, item = itemStack)
 
+        val rawTitle = plugin.configYml.getString("spawner-display.title")
+        if (rawTitle.isNotEmpty()) {
+            fis.setDisplayName(fis.applySpawnerPlaceholders(rawTitle).formatEco(context))
+        }
+
         val lore = plugin.configYml.getStrings("spawner-display.lore")
-            .map { line ->
-                line
-                    .replace("%mob%", fis.spawnerMob ?: "")
-                    .replace("%delay_min%", fis.spawnerDelayMin.toString())
-                    .replace("%delay_max%", fis.spawnerDelayMax.toString())
-                    .replace("%radius%", fis.spawnerSpawnRange.toString())
-                    .replace("%player_range%", fis.spawnerPlayerRange.toString())
-                    .replace("%count%", fis.spawnerSpawnCount.toString())
-                    .replace("%max_nearby%", fis.spawnerMaxNearby.toString())
-                    .replace("%pickup%", fis.spawnerPickup)
-                    .replace("%particle%", fis.spawnerParticleAnim ?: "none")
-            }
-            .map { Display.PREFIX + it.formatEco(context) }
+            .map { Display.PREFIX + fis.applySpawnerPlaceholders(it).formatEco(context) }
 
         fis.lore = lore + fis.lore
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/display/SpawnerItemDisplay.kt
@@ -1,0 +1,40 @@
+package com.willfp.ecomobs.display
+
+import com.willfp.eco.core.display.Display
+import com.willfp.eco.core.display.DisplayModule
+import com.willfp.eco.core.display.DisplayPriority
+import com.willfp.eco.core.fast.fast
+import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.isCustomSpawner
+import com.willfp.ecomobs.spawner.spawnerDelayMax
+import com.willfp.ecomobs.spawner.spawnerDelayMin
+import com.willfp.ecomobs.spawner.spawnerMaxNearby
+import com.willfp.ecomobs.spawner.spawnerMob
+import com.willfp.ecomobs.spawner.spawnerParticleAnim
+import com.willfp.ecomobs.spawner.spawnerPickup
+import com.willfp.ecomobs.spawner.spawnerPlayerRange
+import com.willfp.ecomobs.spawner.spawnerSpawnCount
+import com.willfp.ecomobs.spawner.spawnerSpawnRange
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+object SpawnerItemDisplay : DisplayModule(plugin, DisplayPriority.LOW) {
+    override fun display(itemStack: ItemStack, player: Player?, vararg args: Any) {
+        if (player == null) return
+        val fis = itemStack.fast()
+        if (!fis.isCustomSpawner) return
+
+        val lore = listOf(
+            "${Display.PREFIX}&8Mob: &f${fis.spawnerMob}",
+            "${Display.PREFIX}&8Delay: &f${fis.spawnerDelayMin}-${fis.spawnerDelayMax} ticks",
+            "${Display.PREFIX}&8Radius: &f${fis.spawnerSpawnRange}",
+            "${Display.PREFIX}&8Player Range: &f${fis.spawnerPlayerRange}",
+            "${Display.PREFIX}&8Count: &f${fis.spawnerSpawnCount}",
+            "${Display.PREFIX}&8Max Nearby: &f${fis.spawnerMaxNearby}",
+            "${Display.PREFIX}&8Pickup: &f${fis.spawnerPickup}",
+            "${Display.PREFIX}&8Particle: &f${fis.spawnerParticleAnim ?: "none"}"
+        )
+
+        fis.lore = lore + fis.lore
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/MountHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/MountHandler.kt
@@ -4,7 +4,7 @@ import com.willfp.ecomobs.mob.impl.ecoMob
 import org.bukkit.entity.Mob
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import org.spigotmc.event.entity.EntityMountEvent
+import org.bukkit.event.entity.EntityMountEvent
 
 object MountHandler : Listener {
     @EventHandler(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -149,7 +149,9 @@ object SpawnerHandler : Listener {
         if (target.type != Material.SPAWNER) return
         val state = target.state as? CreatureSpawner ?: return
         if (!state.isCustomSpawner) return
-        event.cursor = state.toSpawnerItem()
+        val item = state.toSpawnerItem()
+        Display.display(item, player)
+        event.cursor = item
     }
 
     @EventHandler

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -24,11 +24,13 @@ import com.willfp.ecomobs.spawner.toSpawnerItem
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
 import org.bukkit.enchantments.Enchantment
+import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.SpawnerSpawnEvent
+import org.bukkit.event.inventory.InventoryCreativeEvent
 import org.bukkit.event.world.ChunkLoadEvent
 import org.bukkit.event.world.ChunkUnloadEvent
 import org.bukkit.persistence.PersistentDataType
@@ -131,6 +133,17 @@ object SpawnerHandler : Listener {
                 PlacedSpawners.remove(block.location)
             }
         }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handlePickBlock(event: InventoryCreativeEvent) {
+        val player = event.whoClicked as? Player ?: return
+        if (event.cursor.type != Material.SPAWNER) return
+        val target = player.getTargetBlockExact(5) ?: return
+        if (target.type != Material.SPAWNER) return
+        val state = target.state as? CreatureSpawner ?: return
+        if (!state.isCustomSpawner) return
+        event.cursor = state.toSpawnerItem()
     }
 
     @EventHandler

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -1,0 +1,150 @@
+package com.willfp.ecomobs.handler
+
+import com.willfp.eco.core.entities.Entities
+import com.willfp.eco.core.fast.fast
+import com.willfp.ecomobs.mob.EcoMobs
+import com.willfp.ecomobs.mob.SpawnReason
+import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.PlacedSpawner
+import com.willfp.ecomobs.spawner.PlacedSpawners
+import com.willfp.ecomobs.spawner.applyVanillaSettings
+import com.willfp.ecomobs.spawner.isCustomSpawner
+import com.willfp.ecomobs.spawner.spawnerDelayMax
+import com.willfp.ecomobs.spawner.spawnerDelayMin
+import com.willfp.ecomobs.spawner.spawnerMaxNearby
+import com.willfp.ecomobs.spawner.spawnerMob
+import com.willfp.ecomobs.spawner.spawnerParticleAnim
+import com.willfp.ecomobs.spawner.spawnerPickup
+import com.willfp.ecomobs.spawner.spawnerPlayerRange
+import com.willfp.ecomobs.spawner.spawnerSpawnCount
+import com.willfp.ecomobs.spawner.spawnerSpawnRange
+import com.willfp.ecomobs.spawner.toSpawnerItem
+import org.bukkit.Material
+import org.bukkit.block.CreatureSpawner
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.entity.SpawnerSpawnEvent
+import org.bukkit.event.world.ChunkLoadEvent
+import org.bukkit.event.world.ChunkUnloadEvent
+
+object SpawnerHandler : Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    fun handlePlace(event: BlockPlaceEvent) {
+        val fis = event.itemInHand.fast()
+        if (!fis.isCustomSpawner) return
+
+        val mobId = fis.spawnerMob ?: return
+        val animId = fis.spawnerParticleAnim
+        val delayMin = fis.spawnerDelayMin
+        val delayMax = fis.spawnerDelayMax
+        val spawnCount = fis.spawnerSpawnCount
+        val spawnRange = fis.spawnerSpawnRange
+        val playerRange = fis.spawnerPlayerRange
+        val maxNearby = fis.spawnerMaxNearby
+        val pickup = fis.spawnerPickup
+        val location = event.block.location
+
+        plugin.scheduler.runTask(location) {
+            val state = location.block.state as? CreatureSpawner ?: return@runTask
+            state.spawnerMob = mobId
+            state.spawnerDelayMin = delayMin
+            state.spawnerDelayMax = delayMax
+            state.spawnerSpawnCount = spawnCount
+            state.spawnerSpawnRange = spawnRange
+            state.spawnerPlayerRange = playerRange
+            state.spawnerMaxNearby = maxNearby
+            state.spawnerPickup = pickup
+            state.spawnerParticleAnim = animId
+            state.applyVanillaSettings()
+            state.update()
+
+            PlacedSpawners.set(location, PlacedSpawner(location, animId))
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handleSpawn(event: SpawnerSpawnEvent) {
+        val state = event.spawner ?: return
+        val mobId = state.spawnerMob ?: return
+
+        event.isCancelled = true
+        val location = event.location
+
+        val ecoMob = EcoMobs[mobId]
+        if (ecoMob != null) {
+            ecoMob.spawn(location, SpawnReason.SPAWNER)
+            return
+        }
+
+        Entities.lookup(mobId).spawn(location)
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handleBreak(event: BlockBreakEvent) {
+        val block = event.block
+        if (block.type != Material.SPAWNER) return
+
+        val state = block.state as? CreatureSpawner ?: return
+        if (!state.isCustomSpawner) return
+
+        val player = event.player
+        val pickup = state.spawnerPickup
+
+        when (pickup) {
+            "deny" -> {
+                PlacedSpawners.remove(block.location)
+            }
+
+            "allow" -> {
+                if (!player.hasPermission("ecomobs.spawner.pickup")) {
+                    event.isCancelled = true
+                    player.sendMessage(plugin.langYml.getMessage("spawner-cannot-pickup"))
+                    return
+                }
+                event.isDropItems = false
+                block.world.dropItemNaturally(block.location, state.toSpawnerItem())
+                PlacedSpawners.remove(block.location)
+            }
+
+            "silk_touch" -> {
+                if (!player.hasPermission("ecomobs.spawner.pickup.silktouch")) {
+                    event.isCancelled = true
+                    player.sendMessage(plugin.langYml.getMessage("spawner-cannot-pickup"))
+                    return
+                }
+                val hasSilkTouch = player.inventory.itemInMainHand
+                    .itemMeta?.enchants?.containsKey(Enchantment.SILK_TOUCH) == true
+                if (hasSilkTouch) {
+                    event.isDropItems = false
+                    block.world.dropItemNaturally(block.location, state.toSpawnerItem())
+                }
+                PlacedSpawners.remove(block.location)
+            }
+        }
+    }
+
+    @EventHandler
+    fun handleChunkLoad(event: ChunkLoadEvent) {
+        for (blockState in event.chunk.tileEntities) {
+            if (blockState !is CreatureSpawner) continue
+            if (!blockState.isCustomSpawner) continue
+            PlacedSpawners.set(
+                blockState.location,
+                PlacedSpawner(blockState.location, blockState.spawnerParticleAnim)
+            )
+        }
+    }
+
+    @EventHandler
+    fun handleChunkUnload(event: ChunkUnloadEvent) {
+        for (blockState in event.chunk.tileEntities) {
+            if (blockState !is CreatureSpawner) continue
+            if (!blockState.isCustomSpawner) continue
+            PlacedSpawners.remove(blockState.location)
+        }
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -18,6 +18,7 @@ import com.willfp.ecomobs.spawner.spawnerPickup
 import com.willfp.ecomobs.spawner.spawnerPlayerRange
 import com.willfp.ecomobs.spawner.spawnerSpawnCount
 import com.willfp.ecomobs.spawner.spawnerSpawnRange
+import com.willfp.ecomobs.spawner.resolveEntityType
 import com.willfp.ecomobs.spawner.toSpawnerItem
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
@@ -60,6 +61,7 @@ object SpawnerHandler : Listener {
             state.spawnerPickup = pickup
             state.spawnerParticleAnim = animId
             state.applyVanillaSettings()
+            resolveEntityType(mobId)?.let { state.spawnedType = it }
             state.update()
 
             PlacedSpawners.set(location, PlacedSpawner(location, animId))

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -18,6 +18,7 @@ import com.willfp.ecomobs.spawner.spawnerPickup
 import com.willfp.ecomobs.spawner.spawnerPlayerRange
 import com.willfp.ecomobs.spawner.spawnerSpawnCount
 import com.willfp.ecomobs.spawner.spawnerSpawnRange
+import com.willfp.ecomobs.spawner.entityFromSpawnerKey
 import com.willfp.ecomobs.spawner.resolveEntityType
 import com.willfp.ecomobs.spawner.toSpawnerItem
 import org.bukkit.Material
@@ -30,6 +31,7 @@ import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.SpawnerSpawnEvent
 import org.bukkit.event.world.ChunkLoadEvent
 import org.bukkit.event.world.ChunkUnloadEvent
+import org.bukkit.persistence.PersistentDataType
 
 object SpawnerHandler : Listener {
 
@@ -78,11 +80,13 @@ object SpawnerHandler : Listener {
 
         val ecoMob = EcoMobs[mobId]
         if (ecoMob != null) {
-            ecoMob.spawn(location, SpawnReason.SPAWNER)
+            val livingMob = ecoMob.spawn(location, SpawnReason.SPAWNER)
+            livingMob?.entity?.persistentDataContainer?.set(entityFromSpawnerKey, PersistentDataType.BYTE, 1)
             return
         }
 
-        Entities.lookup(mobId).spawn(location)
+        val entity = Entities.lookup(mobId).spawn(location)
+        entity?.persistentDataContainer?.set(entityFromSpawnerKey, PersistentDataType.BYTE, 1)
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -1,5 +1,6 @@
 package com.willfp.ecomobs.handler
 
+import com.willfp.eco.core.display.Display
 import com.willfp.eco.core.entities.Entities
 import com.willfp.eco.core.fast.fast
 import com.willfp.ecomobs.mob.EcoMobs
@@ -20,6 +21,7 @@ import com.willfp.ecomobs.spawner.spawnerSpawnCount
 import com.willfp.ecomobs.spawner.spawnerSpawnRange
 import com.willfp.ecomobs.spawner.entityFromSpawnerKey
 import com.willfp.ecomobs.spawner.resolveEntityType
+import com.willfp.ecomobs.spawner.spawnerExplosionProof
 import com.willfp.ecomobs.spawner.toSpawnerItem
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
@@ -28,7 +30,9 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockExplodeEvent
 import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.entity.EntityExplodeEvent
 import org.bukkit.event.entity.SpawnerSpawnEvent
 import org.bukkit.event.inventory.InventoryCreativeEvent
 import org.bukkit.event.world.ChunkLoadEvent
@@ -51,6 +55,7 @@ object SpawnerHandler : Listener {
         val playerRange = fis.spawnerPlayerRange
         val maxNearby = fis.spawnerMaxNearby
         val pickup = fis.spawnerPickup
+        val explosionProof = fis.spawnerExplosionProof
         val location = event.block.location
 
         plugin.scheduler.runTask(location) {
@@ -64,6 +69,7 @@ object SpawnerHandler : Listener {
             state.spawnerMaxNearby = maxNearby
             state.spawnerPickup = pickup
             state.spawnerParticleAnim = animId
+            state.spawnerExplosionProof = explosionProof
             state.applyVanillaSettings()
             resolveEntityType(mobId)?.let { state.spawnedType = it }
             state.update()
@@ -164,6 +170,30 @@ object SpawnerHandler : Listener {
             if (blockState !is CreatureSpawner) continue
             if (!blockState.isCustomSpawner) continue
             PlacedSpawners.remove(blockState.location)
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handleEntityExplosion(event: EntityExplodeEvent) {
+        event.blockList().removeIf { block ->
+            if (block.type != Material.SPAWNER) return@removeIf false
+            val state = block.state as? CreatureSpawner ?: return@removeIf false
+            if (!state.isCustomSpawner) return@removeIf false
+            if (state.spawnerExplosionProof) return@removeIf true
+            PlacedSpawners.remove(block.location)
+            false
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    fun handleBlockExplosion(event: BlockExplodeEvent) {
+        event.blockList().removeIf { block ->
+            if (block.type != Material.SPAWNER) return@removeIf false
+            val state = block.state as? CreatureSpawner ?: return@removeIf false
+            if (!state.isCustomSpawner) return@removeIf false
+            if (state.spawnerExplosionProof) return@removeIf true
+            PlacedSpawners.remove(block.location)
+            false
         }
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/handler/SpawnerHandler.kt
@@ -9,9 +9,12 @@ import com.willfp.ecomobs.plugin
 import com.willfp.ecomobs.spawner.PlacedSpawner
 import com.willfp.ecomobs.spawner.PlacedSpawners
 import com.willfp.ecomobs.spawner.applyVanillaSettings
+import com.willfp.ecomobs.spawner.entityFromSpawnerKey
 import com.willfp.ecomobs.spawner.isCustomSpawner
+import com.willfp.ecomobs.spawner.resolveEntityType
 import com.willfp.ecomobs.spawner.spawnerDelayMax
 import com.willfp.ecomobs.spawner.spawnerDelayMin
+import com.willfp.ecomobs.spawner.spawnerExplosionProof
 import com.willfp.ecomobs.spawner.spawnerMaxNearby
 import com.willfp.ecomobs.spawner.spawnerMob
 import com.willfp.ecomobs.spawner.spawnerParticleAnim
@@ -19,14 +22,11 @@ import com.willfp.ecomobs.spawner.spawnerPickup
 import com.willfp.ecomobs.spawner.spawnerPlayerRange
 import com.willfp.ecomobs.spawner.spawnerSpawnCount
 import com.willfp.ecomobs.spawner.spawnerSpawnRange
-import com.willfp.ecomobs.spawner.entityFromSpawnerKey
-import com.willfp.ecomobs.spawner.resolveEntityType
-import com.willfp.ecomobs.spawner.spawnerExplosionProof
 import com.willfp.ecomobs.spawner.toSpawnerItem
+import io.papermc.paper.event.player.PlayerPickItemEvent
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
 import org.bukkit.enchantments.Enchantment
-import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
@@ -34,7 +34,6 @@ import org.bukkit.event.block.BlockExplodeEvent
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityExplodeEvent
 import org.bukkit.event.entity.SpawnerSpawnEvent
-import org.bukkit.event.inventory.InventoryCreativeEvent
 import org.bukkit.event.world.ChunkLoadEvent
 import org.bukkit.event.world.ChunkUnloadEvent
 import org.bukkit.persistence.PersistentDataType
@@ -142,16 +141,17 @@ object SpawnerHandler : Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
-    fun handlePickBlock(event: InventoryCreativeEvent) {
-        val player = event.whoClicked as? Player ?: return
-        if (event.cursor.type != Material.SPAWNER) return
+    fun handlePickBlock(event: PlayerPickItemEvent) {
+        val player = event.player
         val target = player.getTargetBlockExact(5) ?: return
         if (target.type != Material.SPAWNER) return
         val state = target.state as? CreatureSpawner ?: return
         if (!state.isCustomSpawner) return
         val item = state.toSpawnerItem()
         Display.display(item, player)
-        event.cursor = item
+        plugin.scheduler.runTask(player.location) {
+            player.inventory.setItem(player.inventory.heldItemSlot, item)
+        }
     }
 
     @EventHandler

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/SpawnReason.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/SpawnReason.kt
@@ -4,5 +4,6 @@ enum class SpawnReason {
     NATURAL,
     TOTEM,
     EGG,
-    COMMAND
+    COMMAND,
+    SPAWNER
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/impl/ConfigDrivenEcoMob.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/impl/ConfigDrivenEcoMob.kt
@@ -87,6 +87,9 @@ internal class ConfigDrivenEcoMob(
             )
         }
 
+    /** The first token of the mob lookup string, e.g. "zombie" from "zombie attack-damage:90". */
+    val baseMobId: String = config.getString("mob").split(" ").first()
+
     override val category = MobCategories[config.getString("category")]
         .validateNotNull(
             ConfigViolation(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/placeholder/impl/MobPlaceholderHealthPercent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/placeholder/impl/MobPlaceholderHealthPercent.kt
@@ -3,11 +3,12 @@ package com.willfp.ecomobs.mob.placeholder.impl
 import com.willfp.eco.util.toNiceString
 import com.willfp.ecomobs.mob.LivingMob
 import com.willfp.ecomobs.mob.placeholder.MobPlaceholder
+import org.bukkit.attribute.Attribute
 
 object MobPlaceholderHealthPercent : MobPlaceholder("health_percent") {
     override fun getValue(mob: LivingMob): String {
         val health = mob.entity.health
-        val maxHealth = mob.entity.getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH)?.value ?: return "0"
+        val maxHealth = mob.entity.getAttribute(Attribute.MAX_HEALTH)?.value ?: return "0"
 
         return (health / maxHealth * 100).toNiceString()
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/placeholder/impl/MobPlaceholderMaxHealth.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/mob/placeholder/impl/MobPlaceholderMaxHealth.kt
@@ -7,6 +7,6 @@ import org.bukkit.attribute.Attribute
 
 object MobPlaceholderMaxHealth : MobPlaceholder("max_health") {
     override fun getValue(mob: LivingMob): String {
-        return mob.entity.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value.toNiceString()
+        return mob.entity.getAttribute(Attribute.MAX_HEALTH)?.value.toNiceString()
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/PlacedSpawner.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/PlacedSpawner.kt
@@ -1,0 +1,18 @@
+package com.willfp.ecomobs.spawner
+
+import org.bukkit.Location
+
+class PlacedSpawner(
+    val location: Location,
+    val animationId: String?
+) {
+    fun tickAsync(tick: Int) {
+        val id = animationId?.takeIf { it != "none" } ?: return
+        val data = SpawnerAnimations[id] ?: return
+        data.animation.spawnParticle(
+            location.clone().add(0.5, 0.5, 0.5),
+            tick,
+            data.particle
+        )
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/PlacedSpawners.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/PlacedSpawners.kt
@@ -6,8 +6,6 @@ import java.util.concurrent.ConcurrentHashMap
 object PlacedSpawners {
     private val loaded = ConcurrentHashMap<Location, PlacedSpawner>()
 
-    fun getAt(location: Location): PlacedSpawner? = loaded[location]
-
     fun set(location: Location, spawner: PlacedSpawner) {
         loaded[location] = spawner
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/PlacedSpawners.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/PlacedSpawners.kt
@@ -1,0 +1,20 @@
+package com.willfp.ecomobs.spawner
+
+import org.bukkit.Location
+import java.util.concurrent.ConcurrentHashMap
+
+object PlacedSpawners {
+    private val loaded = ConcurrentHashMap<Location, PlacedSpawner>()
+
+    fun getAt(location: Location): PlacedSpawner? = loaded[location]
+
+    fun set(location: Location, spawner: PlacedSpawner) {
+        loaded[location] = spawner
+    }
+
+    fun remove(location: Location) {
+        loaded.remove(location)
+    }
+
+    fun values(): List<PlacedSpawner> = loaded.values.toList()
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerAnimations.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerAnimations.kt
@@ -1,0 +1,27 @@
+package com.willfp.ecomobs.spawner
+
+import com.willfp.eco.core.particle.Particles
+import com.willfp.ecomobs.plugin
+import com.willfp.ecomobs.spawner.particle.ParticleData
+import com.willfp.ecomobs.spawner.particle.SpawnerParticleAnimations
+
+object SpawnerAnimations {
+    private val animations = mutableMapOf<String, ParticleData>()
+
+    fun reload() {
+        animations.clear()
+        SpawnerParticleAnimations.reload()
+
+        for (id in plugin.configYml.getSubsection("spawner-animations").getKeys(false)) {
+            val section = plugin.configYml.getSubsection("spawner-animations.$id")
+            val particle = Particles.lookup(section.getString("particle"))
+            val anim = SpawnerParticleAnimations[section.getString("type")]
+                ?: SpawnerParticleAnimations.SPIRAL
+            animations[id] = ParticleData(particle, anim)
+        }
+    }
+
+    operator fun get(id: String): ParticleData? = animations[id]
+
+    fun keys(): Set<String> = animations.keys
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerDisplay.kt
@@ -1,0 +1,26 @@
+package com.willfp.ecomobs.spawner
+
+import com.willfp.eco.core.scheduling.EcoWrappedTask
+import com.willfp.ecomobs.plugin
+
+object SpawnerDisplay {
+    @Volatile
+    private var tick = 0
+    private var asyncTask: EcoWrappedTask? = null
+
+    fun start() {
+        asyncTask?.cancelTask()
+        asyncTask = plugin.scheduler.runTaskAsyncTimer(1, 1) { tickAsync() }
+    }
+
+    private fun tickAsync() {
+        for (spawner in PlacedSpawners.values()) {
+            plugin.scheduler.runTask(spawner.location) {
+                if (spawner.location.isChunkLoaded) {
+                    spawner.tickAsync(tick)
+                }
+            }
+        }
+        tick++
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerItemModifier.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerItemModifier.kt
@@ -1,0 +1,77 @@
+package com.willfp.ecomobs.spawner
+
+import com.willfp.eco.core.fast.FastItemStack
+import com.willfp.ecomobs.mob.EcoMobs
+import com.willfp.ecomobs.spawner.spawnerExplosionProof
+import org.bukkit.entity.EntityType
+
+val PICKUP_VALUES = listOf("allow", "silk_touch", "deny")
+
+object SpawnerItemModifier {
+    val ATTRIBUTES = listOf("mob", "delay", "radius", "player-radius", "count", "max-nearby", "pickup", "particle", "explosion-proof")
+
+    fun valueCount(attribute: String): Int = if (attribute == "delay") 2 else 1
+
+    fun apply(fis: FastItemStack, attribute: String, args: List<String>): Boolean {
+        when (attribute) {
+            "mob" -> {
+                val mobId = args.getOrNull(0) ?: return false
+                val valid = EcoMobs[mobId] != null || runCatching {
+                    EntityType.valueOf(mobId.uppercase())
+                }.isSuccess
+                if (!valid) return false
+                fis.spawnerMob = mobId
+            }
+            "delay" -> {
+                val min = args.getOrNull(0)?.toIntOrNull()
+                val max = args.getOrNull(1)?.toIntOrNull()
+                if (min == null || max == null || min < 0 || min > max) return false
+                fis.spawnerDelayMin = min
+                fis.spawnerDelayMax = max
+            }
+            "radius" -> {
+                val value = args.getOrNull(0)?.toIntOrNull()?.takeIf { it >= 1 } ?: return false
+                fis.spawnerSpawnRange = value
+            }
+            "player-radius" -> {
+                val value = args.getOrNull(0)?.toIntOrNull()?.takeIf { it >= 1 } ?: return false
+                fis.spawnerPlayerRange = value
+            }
+            "count" -> {
+                val value = args.getOrNull(0)?.toIntOrNull()?.takeIf { it >= 1 } ?: return false
+                fis.spawnerSpawnCount = value
+            }
+            "max-nearby" -> {
+                val value = args.getOrNull(0)?.toIntOrNull()?.takeIf { it >= 1 } ?: return false
+                fis.spawnerMaxNearby = value
+            }
+            "pickup" -> {
+                val raw = args.getOrNull(0)?.lowercase() ?: return false
+                val value = if (raw == "silk-touch") "silk_touch" else raw
+                if (value !in PICKUP_VALUES) return false
+                fis.spawnerPickup = value
+            }
+            "particle" -> {
+                val value = args.getOrNull(0)?.lowercase() ?: return false
+                if (value != "none" && SpawnerAnimations[value] == null) return false
+                fis.spawnerParticleAnim = if (value == "none") null else value
+            }
+            "explosion-proof" -> {
+                val value = args.getOrNull(0)?.lowercase() ?: return false
+                if (value != "true" && value != "false") return false
+                fis.spawnerExplosionProof = value == "true"
+            }
+            else -> return false
+        }
+        return true
+    }
+
+    fun tabComplete(attribute: String, valueIndex: Int): List<String> = when (attribute) {
+        "mob" -> EcoMobs.values().map { it.id } + EntityType.entries.map { it.name.lowercase() }
+        "delay" -> if (valueIndex == 0) listOf("200", "400", "800") else listOf("400", "800", "1600")
+        "pickup" -> PICKUP_VALUES
+        "particle" -> listOf("none") + SpawnerAnimations.keys()
+        "explosion-proof" -> listOf("true", "false")
+        else -> listOf("1", "4", "8", "16")
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
@@ -1,0 +1,189 @@
+// spawner/SpawnerKeys.kt
+package com.willfp.ecomobs.spawner
+
+import com.willfp.eco.core.fast.FastItemStack
+import com.willfp.eco.core.fast.fast
+import com.willfp.eco.util.namespacedKeyOf
+import org.bukkit.Material
+import org.bukkit.block.CreatureSpawner
+import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
+
+val spawnerMobKey = namespacedKeyOf("ecomobs", "spawner_mob")
+val spawnerDelayMinKey = namespacedKeyOf("ecomobs", "spawner_delay_min")
+val spawnerDelayMaxKey = namespacedKeyOf("ecomobs", "spawner_delay_max")
+val spawnerSpawnCountKey = namespacedKeyOf("ecomobs", "spawner_spawn_count")
+val spawnerSpawnRangeKey = namespacedKeyOf("ecomobs", "spawner_spawn_range")
+val spawnerPlayerRangeKey = namespacedKeyOf("ecomobs", "spawner_player_range")
+val spawnerMaxNearbyKey = namespacedKeyOf("ecomobs", "spawner_max_nearby")
+val spawnerPickupKey = namespacedKeyOf("ecomobs", "spawner_pickup")
+val spawnerParticleAnimKey = namespacedKeyOf("ecomobs", "spawner_particle_anim")
+
+// ── FastItemStack extensions ──────────────────────────────────────────────────
+
+val FastItemStack.isCustomSpawner: Boolean
+    get() = persistentDataContainer.has(spawnerMobKey, PersistentDataType.STRING)
+
+var FastItemStack.spawnerMob: String?
+    get() = persistentDataContainer.get(spawnerMobKey, PersistentDataType.STRING)
+    set(value) {
+        if (value == null) persistentDataContainer.remove(spawnerMobKey)
+        else persistentDataContainer.set(spawnerMobKey, PersistentDataType.STRING, value)
+    }
+
+var FastItemStack.spawnerDelayMin: Int
+    get() = persistentDataContainer.get(spawnerDelayMinKey, PersistentDataType.INTEGER) ?: 200
+    set(value) {
+        persistentDataContainer.set(spawnerDelayMinKey, PersistentDataType.INTEGER, value)
+    }
+
+var FastItemStack.spawnerDelayMax: Int
+    get() = persistentDataContainer.get(spawnerDelayMaxKey, PersistentDataType.INTEGER) ?: 800
+    set(value) {
+        persistentDataContainer.set(spawnerDelayMaxKey, PersistentDataType.INTEGER, value)
+    }
+
+var FastItemStack.spawnerSpawnCount: Int
+    get() = persistentDataContainer.get(spawnerSpawnCountKey, PersistentDataType.INTEGER) ?: 4
+    set(value) {
+        persistentDataContainer.set(spawnerSpawnCountKey, PersistentDataType.INTEGER, value)
+    }
+
+var FastItemStack.spawnerSpawnRange: Int
+    get() = persistentDataContainer.get(spawnerSpawnRangeKey, PersistentDataType.INTEGER) ?: 4
+    set(value) {
+        persistentDataContainer.set(spawnerSpawnRangeKey, PersistentDataType.INTEGER, value)
+    }
+
+var FastItemStack.spawnerPlayerRange: Int
+    get() = persistentDataContainer.get(spawnerPlayerRangeKey, PersistentDataType.INTEGER) ?: 16
+    set(value) {
+        persistentDataContainer.set(spawnerPlayerRangeKey, PersistentDataType.INTEGER, value)
+    }
+
+var FastItemStack.spawnerMaxNearby: Int
+    get() = persistentDataContainer.get(spawnerMaxNearbyKey, PersistentDataType.INTEGER) ?: 6
+    set(value) {
+        persistentDataContainer.set(spawnerMaxNearbyKey, PersistentDataType.INTEGER, value)
+    }
+
+var FastItemStack.spawnerPickup: String
+    get() = persistentDataContainer.get(spawnerPickupKey, PersistentDataType.STRING) ?: "deny"
+    set(value) {
+        persistentDataContainer.set(spawnerPickupKey, PersistentDataType.STRING, value)
+    }
+
+var FastItemStack.spawnerParticleAnim: String?
+    get() = persistentDataContainer.get(spawnerParticleAnimKey, PersistentDataType.STRING)
+    set(value) {
+        if (value == null) persistentDataContainer.remove(spawnerParticleAnimKey)
+        else persistentDataContainer.set(spawnerParticleAnimKey, PersistentDataType.STRING, value)
+    }
+
+// ── ItemStack convenience extensions ─────────────────────────────────────────
+
+val ItemStack.isCustomSpawner: Boolean get() = fast().isCustomSpawner
+var ItemStack.spawnerMob: String?
+    get() = fast().spawnerMob
+    set(value) {
+        fast().spawnerMob = value
+    }
+
+// ── CreatureSpawner (block state) extensions ──────────────────────────────────
+
+val CreatureSpawner.isCustomSpawner: Boolean
+    get() = persistentDataContainer.has(spawnerMobKey, PersistentDataType.STRING)
+
+var CreatureSpawner.spawnerMob: String?
+    get() = persistentDataContainer.get(spawnerMobKey, PersistentDataType.STRING)
+    set(value) {
+        if (value == null) persistentDataContainer.remove(spawnerMobKey)
+        else persistentDataContainer.set(spawnerMobKey, PersistentDataType.STRING, value)
+    }
+
+var CreatureSpawner.spawnerDelayMin: Int
+    get() = persistentDataContainer.get(spawnerDelayMinKey, PersistentDataType.INTEGER) ?: 200
+    set(value) {
+        persistentDataContainer.set(spawnerDelayMinKey, PersistentDataType.INTEGER, value)
+    }
+
+var CreatureSpawner.spawnerDelayMax: Int
+    get() = persistentDataContainer.get(spawnerDelayMaxKey, PersistentDataType.INTEGER) ?: 800
+    set(value) {
+        persistentDataContainer.set(spawnerDelayMaxKey, PersistentDataType.INTEGER, value)
+    }
+
+var CreatureSpawner.spawnerSpawnCount: Int
+    get() = persistentDataContainer.get(spawnerSpawnCountKey, PersistentDataType.INTEGER) ?: 4
+    set(value) {
+        persistentDataContainer.set(spawnerSpawnCountKey, PersistentDataType.INTEGER, value)
+    }
+
+var CreatureSpawner.spawnerSpawnRange: Int
+    get() = persistentDataContainer.get(spawnerSpawnRangeKey, PersistentDataType.INTEGER) ?: 4
+    set(value) {
+        persistentDataContainer.set(spawnerSpawnRangeKey, PersistentDataType.INTEGER, value)
+    }
+
+var CreatureSpawner.spawnerPlayerRange: Int
+    get() = persistentDataContainer.get(spawnerPlayerRangeKey, PersistentDataType.INTEGER) ?: 16
+    set(value) {
+        persistentDataContainer.set(spawnerPlayerRangeKey, PersistentDataType.INTEGER, value)
+    }
+
+var CreatureSpawner.spawnerMaxNearby: Int
+    get() = persistentDataContainer.get(spawnerMaxNearbyKey, PersistentDataType.INTEGER) ?: 6
+    set(value) {
+        persistentDataContainer.set(spawnerMaxNearbyKey, PersistentDataType.INTEGER, value)
+    }
+
+var CreatureSpawner.spawnerPickup: String
+    get() = persistentDataContainer.get(spawnerPickupKey, PersistentDataType.STRING) ?: "deny"
+    set(value) {
+        persistentDataContainer.set(spawnerPickupKey, PersistentDataType.STRING, value)
+    }
+
+var CreatureSpawner.spawnerParticleAnim: String?
+    get() = persistentDataContainer.get(spawnerParticleAnimKey, PersistentDataType.STRING)
+    set(value) {
+        if (value == null) persistentDataContainer.remove(spawnerParticleAnimKey)
+        else persistentDataContainer.set(spawnerParticleAnimKey, PersistentDataType.STRING, value)
+    }
+
+// ── Transfer helpers ──────────────────────────────────────────────────────────
+
+fun FastItemStack.copySpawnerPdcTo(state: CreatureSpawner) {
+    state.spawnerMob = spawnerMob
+    state.spawnerDelayMin = spawnerDelayMin
+    state.spawnerDelayMax = spawnerDelayMax
+    state.spawnerSpawnCount = spawnerSpawnCount
+    state.spawnerSpawnRange = spawnerSpawnRange
+    state.spawnerPlayerRange = spawnerPlayerRange
+    state.spawnerMaxNearby = spawnerMaxNearby
+    state.spawnerPickup = spawnerPickup
+    state.spawnerParticleAnim = spawnerParticleAnim
+}
+
+fun CreatureSpawner.applyVanillaSettings() {
+    minSpawnDelay = spawnerDelayMin
+    maxSpawnDelay = spawnerDelayMax
+    spawnCount = spawnerSpawnCount
+    spawnRange = spawnerSpawnRange
+    requiredPlayerRange = spawnerPlayerRange
+    maxNearbyEntities = spawnerMaxNearby
+}
+
+fun CreatureSpawner.toSpawnerItem(): ItemStack {
+    val item = ItemStack(Material.SPAWNER)
+    val fis = item.fast()
+    fis.spawnerMob = spawnerMob
+    fis.spawnerDelayMin = spawnerDelayMin
+    fis.spawnerDelayMax = spawnerDelayMax
+    fis.spawnerSpawnCount = spawnerSpawnCount
+    fis.spawnerSpawnRange = spawnerSpawnRange
+    fis.spawnerPlayerRange = spawnerPlayerRange
+    fis.spawnerMaxNearby = spawnerMaxNearby
+    fis.spawnerPickup = spawnerPickup
+    fis.spawnerParticleAnim = spawnerParticleAnim
+    return fis.unwrap()
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
@@ -1,11 +1,13 @@
-// spawner/SpawnerKeys.kt
 package com.willfp.ecomobs.spawner
 
 import com.willfp.eco.core.fast.FastItemStack
 import com.willfp.eco.core.fast.fast
 import com.willfp.eco.util.namespacedKeyOf
+import com.willfp.ecomobs.mob.EcoMobs
+import com.willfp.ecomobs.mob.impl.ConfigDrivenEcoMob
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
+import org.bukkit.entity.EntityType
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 
@@ -18,8 +20,6 @@ val spawnerPlayerRangeKey = namespacedKeyOf("ecomobs", "spawner_player_range")
 val spawnerMaxNearbyKey = namespacedKeyOf("ecomobs", "spawner_max_nearby")
 val spawnerPickupKey = namespacedKeyOf("ecomobs", "spawner_pickup")
 val spawnerParticleAnimKey = namespacedKeyOf("ecomobs", "spawner_particle_anim")
-
-// ── FastItemStack extensions ──────────────────────────────────────────────────
 
 val FastItemStack.isCustomSpawner: Boolean
     get() = persistentDataContainer.has(spawnerMobKey, PersistentDataType.STRING)
@@ -80,17 +80,6 @@ var FastItemStack.spawnerParticleAnim: String?
         else persistentDataContainer.set(spawnerParticleAnimKey, PersistentDataType.STRING, value)
     }
 
-// ── ItemStack convenience extensions ─────────────────────────────────────────
-
-val ItemStack.isCustomSpawner: Boolean get() = fast().isCustomSpawner
-var ItemStack.spawnerMob: String?
-    get() = fast().spawnerMob
-    set(value) {
-        fast().spawnerMob = value
-    }
-
-// ── CreatureSpawner (block state) extensions ──────────────────────────────────
-
 val CreatureSpawner.isCustomSpawner: Boolean
     get() = persistentDataContainer.has(spawnerMobKey, PersistentDataType.STRING)
 
@@ -150,20 +139,6 @@ var CreatureSpawner.spawnerParticleAnim: String?
         else persistentDataContainer.set(spawnerParticleAnimKey, PersistentDataType.STRING, value)
     }
 
-// ── Transfer helpers ──────────────────────────────────────────────────────────
-
-fun FastItemStack.copySpawnerPdcTo(state: CreatureSpawner) {
-    state.spawnerMob = spawnerMob
-    state.spawnerDelayMin = spawnerDelayMin
-    state.spawnerDelayMax = spawnerDelayMax
-    state.spawnerSpawnCount = spawnerSpawnCount
-    state.spawnerSpawnRange = spawnerSpawnRange
-    state.spawnerPlayerRange = spawnerPlayerRange
-    state.spawnerMaxNearby = spawnerMaxNearby
-    state.spawnerPickup = spawnerPickup
-    state.spawnerParticleAnim = spawnerParticleAnim
-}
-
 fun CreatureSpawner.applyVanillaSettings() {
     minSpawnDelay = spawnerDelayMin
     maxSpawnDelay = spawnerDelayMax
@@ -171,6 +146,19 @@ fun CreatureSpawner.applyVanillaSettings() {
     spawnRange = spawnerSpawnRange
     requiredPlayerRange = spawnerPlayerRange
     maxNearbyEntities = spawnerMaxNearby
+}
+
+/**
+ * Resolves the EntityType for a mob ID so the vanilla spawner preview spins
+ * the correct entity. Handles both plain vanilla IDs and EcoMob IDs.
+ */
+fun resolveEntityType(mobId: String): EntityType? {
+    // Plain vanilla entity type (e.g. "zombie", "ZOMBIE")
+    runCatching { return EntityType.valueOf(mobId.uppercase()) }
+    // EcoMob — derive entity type from the base mob lookup string (e.g. "zombie attack-damage:90")
+    val baseMobString = (EcoMobs[mobId] as? ConfigDrivenEcoMob)
+        ?.baseMobId ?: return null
+    return runCatching { EntityType.valueOf(baseMobString.uppercase()) }.getOrNull()
 }
 
 fun CreatureSpawner.toSpawnerItem(): ItemStack {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
@@ -21,6 +21,7 @@ val spawnerPlayerRangeKey = namespacedKeyOf("ecomobs", "spawner_player_range")
 val spawnerMaxNearbyKey = namespacedKeyOf("ecomobs", "spawner_max_nearby")
 val spawnerPickupKey = namespacedKeyOf("ecomobs", "spawner_pickup")
 val spawnerParticleAnimKey = namespacedKeyOf("ecomobs", "spawner_particle_anim")
+val spawnerExplosionProofKey = namespacedKeyOf("ecomobs", "spawner_explosion_proof")
 
 val FastItemStack.isCustomSpawner: Boolean
     get() = persistentDataContainer.has(spawnerMobKey, PersistentDataType.STRING)
@@ -79,6 +80,12 @@ var FastItemStack.spawnerParticleAnim: String?
     set(value) {
         if (value == null) persistentDataContainer.remove(spawnerParticleAnimKey)
         else persistentDataContainer.set(spawnerParticleAnimKey, PersistentDataType.STRING, value)
+    }
+
+var FastItemStack.spawnerExplosionProof: Boolean
+    get() = persistentDataContainer.get(spawnerExplosionProofKey, PersistentDataType.BYTE) == 1.toByte()
+    set(value) {
+        persistentDataContainer.set(spawnerExplosionProofKey, PersistentDataType.BYTE, if (value) 1 else 0)
     }
 
 val CreatureSpawner.isCustomSpawner: Boolean
@@ -140,6 +147,12 @@ var CreatureSpawner.spawnerParticleAnim: String?
         else persistentDataContainer.set(spawnerParticleAnimKey, PersistentDataType.STRING, value)
     }
 
+var CreatureSpawner.spawnerExplosionProof: Boolean
+    get() = persistentDataContainer.get(spawnerExplosionProofKey, PersistentDataType.BYTE) == 1.toByte()
+    set(value) {
+        persistentDataContainer.set(spawnerExplosionProofKey, PersistentDataType.BYTE, if (value) 1 else 0)
+    }
+
 fun CreatureSpawner.applyVanillaSettings() {
     minSpawnDelay = spawnerDelayMin
     maxSpawnDelay = spawnerDelayMax
@@ -174,5 +187,6 @@ fun CreatureSpawner.toSpawnerItem(): ItemStack {
     fis.spawnerMaxNearby = spawnerMaxNearby
     fis.spawnerPickup = spawnerPickup
     fis.spawnerParticleAnim = spawnerParticleAnim
+    fis.spawnerExplosionProof = spawnerExplosionProof
     return fis.unwrap()
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/SpawnerKeys.kt
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 
 val spawnerMobKey = namespacedKeyOf("ecomobs", "spawner_mob")
+val entityFromSpawnerKey = namespacedKeyOf("ecomobs", "from_spawner")
 val spawnerDelayMinKey = namespacedKeyOf("ecomobs", "spawner_delay_min")
 val spawnerDelayMaxKey = namespacedKeyOf("ecomobs", "spawner_delay_max")
 val spawnerSpawnCountKey = namespacedKeyOf("ecomobs", "spawner_spawn_count")

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/CircleParticleAnimation.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/CircleParticleAnimation.kt
@@ -1,0 +1,27 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.util.NumberUtils
+import org.bukkit.util.Vector
+import kotlin.math.PI
+
+object CircleParticleAnimation : ParticleAnimation("circle") {
+    private var spiralsPerSecond: Double = 0.0
+    private var radius: Double = 0.0
+    private var height: Double = 0.0
+
+    init {
+        reload()
+    }
+
+    override fun getOffset(tick: Int) = Vector(
+        NumberUtils.fastSin(spiralsPerSecond * 2 * PI * tick / 20) * radius,
+        height,
+        NumberUtils.fastCos(spiralsPerSecond * 2 * PI * tick / 20) * radius
+    )
+
+    override fun reloadAnimation() {
+        spiralsPerSecond = config.getDouble("spirals-per-second")
+        radius = config.getDouble("radius")
+        height = config.getDouble("height")
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/DoubleSpiralParticleAnimation.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/DoubleSpiralParticleAnimation.kt
@@ -1,0 +1,29 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.util.NumberUtils
+import org.bukkit.util.Vector
+import kotlin.math.PI
+
+object DoubleSpiralParticleAnimation : ParticleAnimation("double_spiral") {
+    private var spiralsPerSecond: Double = 0.0
+    private var risesPerSecond: Double = 0.0
+    private var radius: Double = 0.0
+    private var height: Double = 0.0
+
+    init {
+        reload()
+    }
+
+    override fun getOffset(tick: Int) = Vector(
+        NumberUtils.fastSin(spiralsPerSecond * 2 * PI * tick / 20) * radius,
+        -NumberUtils.fastCos(risesPerSecond * 2 * PI * tick / 20) * height,
+        NumberUtils.fastCos(spiralsPerSecond * 2 * PI * tick / 20) * radius
+    ).apply { if (tick % 2 == 0) multiply(-1) }
+
+    override fun reloadAnimation() {
+        spiralsPerSecond = config.getDouble("spirals-per-second")
+        risesPerSecond = config.getDouble("rises-per-second")
+        radius = config.getDouble("radius")
+        height = config.getDouble("height")
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/ParticleAnimation.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/ParticleAnimation.kt
@@ -1,0 +1,39 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.core.particle.SpawnableParticle
+import com.willfp.eco.core.registry.Registrable
+import com.willfp.ecomobs.plugin
+import org.bukkit.Location
+import org.bukkit.util.Vector
+
+abstract class ParticleAnimation(val id: String) : Registrable {
+    protected open val config get() = plugin.configYml.getSubsection("animations.$id")
+
+    private var count: Int = 1
+
+    init {
+        @Suppress("LeakingThis")
+        SpawnerParticleAnimations.register(this)
+    }
+
+    fun spawnParticle(center: Location, tick: Int, particle: SpawnableParticle) {
+        val from = getOffset(tick)
+        val to = getOffset(tick + 1)
+        for (i in 0 until count) {
+            val t = if (count == 1) 0.0 else i.toDouble() / (count - 1)
+            val offset = from.clone().add(to.clone().subtract(from).multiply(t))
+            particle.spawn(center.clone().add(offset))
+        }
+    }
+
+    protected abstract fun getOffset(tick: Int): Vector
+
+    fun reload() {
+        count = config.getInt("count", 1)
+        reloadAnimation()
+    }
+
+    protected abstract fun reloadAnimation()
+
+    override fun getID(): String = id
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/ParticleData.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/ParticleData.kt
@@ -1,0 +1,8 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.core.particle.SpawnableParticle
+
+data class ParticleData(
+    val particle: SpawnableParticle,
+    val animation: ParticleAnimation
+)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/SpawnerParticleAnimations.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/SpawnerParticleAnimations.kt
@@ -1,0 +1,15 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.core.registry.Registry
+
+object SpawnerParticleAnimations : Registry<ParticleAnimation>() {
+    val CIRCLE: ParticleAnimation = CircleParticleAnimation
+    val SPIRAL: ParticleAnimation = SpiralParticleAnimation
+    val DOUBLE_SPIRAL: ParticleAnimation = DoubleSpiralParticleAnimation
+    val TILTED_RINGS: ParticleAnimation = TiltedRingsParticleAnimation
+    val TWIRL: ParticleAnimation = TwirlParticleAnimation
+
+    fun reload() {
+        this.forEach { it.reload() }
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/SpiralParticleAnimation.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/SpiralParticleAnimation.kt
@@ -1,0 +1,29 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.util.NumberUtils
+import org.bukkit.util.Vector
+import kotlin.math.PI
+
+object SpiralParticleAnimation : ParticleAnimation("spiral") {
+    private var spiralsPerSecond: Double = 0.0
+    private var risesPerSecond: Double = 0.0
+    private var radius: Double = 0.0
+    private var height: Double = 0.0
+
+    init {
+        reload()
+    }
+
+    override fun getOffset(tick: Int) = Vector(
+        NumberUtils.fastSin(spiralsPerSecond * 2 * PI * tick / 20) * radius,
+        -NumberUtils.fastCos(risesPerSecond * 2 * PI * tick / 20) * height,
+        NumberUtils.fastCos(spiralsPerSecond * 2 * PI * tick / 20) * radius
+    )
+
+    override fun reloadAnimation() {
+        spiralsPerSecond = config.getDouble("spirals-per-second")
+        risesPerSecond = config.getDouble("rises-per-second")
+        radius = config.getDouble("radius")
+        height = config.getDouble("height")
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/TiltedRingsParticleAnimation.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/TiltedRingsParticleAnimation.kt
@@ -1,0 +1,41 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.util.NumberUtils
+import org.bukkit.util.Vector
+import kotlin.math.PI
+
+object TiltedRingsParticleAnimation : ParticleAnimation("tilted_rings") {
+    private var spiralsPerSecond: Double = 0.0
+    private var radius: Double = 0.0
+    private var xOffset: Double = 0.0
+    private var yOffset: Double = 0.0
+
+    init {
+        reload()
+    }
+
+    override fun getOffset(tick: Int): Vector {
+        val base = if (tick % 2 == 0) {
+            Vector(
+                NumberUtils.fastSin(spiralsPerSecond * 4 * PI * tick / 20) * radius,
+                0.0,
+                NumberUtils.fastCos(spiralsPerSecond * 4 * PI * tick / 20) * radius
+            )
+        } else {
+            Vector(
+                0.0,
+                NumberUtils.fastSin(spiralsPerSecond * 4 * PI * tick / 20) * radius,
+                NumberUtils.fastCos(spiralsPerSecond * 4 * PI * tick / 20) * radius
+            )
+        }
+        return base.rotateAroundY(NumberUtils.fastCos(yOffset))
+            .rotateAroundX(NumberUtils.fastCos(xOffset))
+    }
+
+    override fun reloadAnimation() {
+        spiralsPerSecond = config.getDouble("spirals-per-second")
+        radius = config.getDouble("radius")
+        xOffset = config.getDouble("x-offset")
+        yOffset = config.getDouble("y-offset")
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/TwirlParticleAnimation.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/spawner/particle/TwirlParticleAnimation.kt
@@ -1,0 +1,41 @@
+package com.willfp.ecomobs.spawner.particle
+
+import com.willfp.eco.util.NumberUtils
+import org.bukkit.util.Vector
+import kotlin.math.PI
+
+private fun lerp(start: Double, end: Double, fraction: Double): Double =
+    (start * (1 - fraction)) + (end * fraction)
+
+object TwirlParticleAnimation : ParticleAnimation("twirl") {
+    private var smallRadius: Double = 0.0
+    private var largeRadius: Double = 0.0
+    private var ticks: Double = 40.0
+    private var startHeight: Double = 0.0
+    private var endHeight: Double = 0.0
+    private var spiralsPerSecond: Double = 0.0
+
+    init {
+        reload()
+    }
+
+    override fun getOffset(tick: Int): Vector {
+        val radius = lerp(smallRadius, largeRadius, (tick % ticks) / ticks)
+        val height = lerp(startHeight, endHeight, (tick % ticks) / ticks)
+        val v = Vector(
+            NumberUtils.fastSin(spiralsPerSecond * 2 * PI * tick / 20) * radius,
+            height,
+            NumberUtils.fastCos(spiralsPerSecond * 2 * PI * tick / 20) * radius
+        )
+        return if (tick % 2 == 0) v.setX(-v.x).setZ(-v.z) else v
+    }
+
+    override fun reloadAnimation() {
+        smallRadius = config.getDouble("small-radius")
+        largeRadius = config.getDouble("large-radius")
+        ticks = config.getDouble("ticks")
+        startHeight = config.getDouble("start-height")
+        endHeight = config.getDouble("end-height")
+        spiralsPerSecond = config.getDouble("spirals-per-second")
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/tick/TickHandlerBossBar.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecomobs/tick/TickHandlerBossBar.kt
@@ -19,7 +19,7 @@ class TickHandlerBossBar(
         }
 
         val entity = mob.entity
-        val maxHealth = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value
+        val maxHealth = entity.getAttribute(Attribute.MAX_HEALTH)?.value
             ?: throw IllegalStateException("Entity ${entity.type} has no max health attribute")
 
         bar.name(mob.displayName.toComponent())

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -21,3 +21,44 @@ custom-spawning:
 
   # The max amount of attempts to generate a spawn point per player
   max-attempts: 64
+
+animations:
+  circle:
+    spirals-per-second: 0.5
+    radius: 1.0
+    height: 0.5
+    count: 1
+  spiral:
+    spirals-per-second: 0.5
+    rises-per-second: 0.3
+    radius: 1.0
+    height: 0.5
+    count: 1
+  double_spiral:
+    spirals-per-second: 0.5
+    rises-per-second: 0.3
+    radius: 1.0
+    height: 0.5
+    count: 1
+  tilted_rings:
+    spirals-per-second: 0.5
+    radius: 1.0
+    x-offset: 0.5
+    y-offset: 0.5
+    count: 1
+  twirl:
+    small-radius: 0.2
+    large-radius: 1.0
+    ticks: 40.0
+    start-height: 0.0
+    end-height: 1.0
+    spirals-per-second: 0.5
+    count: 1
+
+spawner-animations:
+  circle_flame:
+    particle: flame
+    type: circle
+  spiral_end_rod:
+    particle: end_rod
+    type: spiral

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -22,6 +22,17 @@ custom-spawning:
   # The max amount of attempts to generate a spawn point per player
   max-attempts: 64
 
+spawner-display:
+  lore:
+    - "&8Mob: &f%mob%"
+    - "&8Delay: &f%delay_min%-%delay_max% ticks"
+    - "&8Radius: &f%radius%"
+    - "&8Player Range: &f%player_range%"
+    - "&8Count: &f%count%"
+    - "&8Max Nearby: &f%max_nearby%"
+    - "&8Pickup: &f%pickup%"
+    - "&8Particle: &f%particle%"
+
 animations:
   circle:
     spirals-per-second: 0.5

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -23,6 +23,7 @@ custom-spawning:
   max-attempts: 64
 
 spawner-display:
+  title: "&f%mob% Spawner"
   lore:
     - "&8Mob: &f%mob%"
     - "&8Delay: &f%delay_min%-%delay_max% ticks"

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -33,6 +33,7 @@ spawner-display:
     - "&8Max Nearby: &f%max_nearby%"
     - "&8Pickup: &f%pickup%"
     - "&8Particle: &f%particle%"
+    - "&8Explosion-Proof: &f%explosion_proof%"
 
 animations:
   circle:

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -12,4 +12,11 @@ messages:
   spawned: "Spawned %mob%&f!"
   gave-egg: "Gave %player%&f a %mob%&f egg!"
 
+  spawner-give: "Gave %player% a &c%mob%&f spawner!"
+  spawner-invalid-mob: "&cInvalid mob! Specify a valid EcoMob ID or vanilla entity type."
+  spawner-no-target: "&cYou must be holding a spawner or looking at one within 5 blocks!"
+  spawner-modified: "&aSet &c%attribute%&a to &c%value%&a!"
+  spawner-invalid-value: "&cInvalid value for &c%attribute%&c!"
+  spawner-cannot-pickup: "&cYou don't have permission to pick up this spawner!"
+
 na: "N/A"

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -26,6 +26,7 @@ permissions:
     default: op
     children:
       ecomobs.command.*: true
+      ecomobs.spawner.*: true
   ecomobs.command.*:
     description: All ecomobs commands
     default: op
@@ -34,6 +35,7 @@ permissions:
       ecomobs.command.reload: true
       ecomobs.command.spawn: true
       ecomobs.command.give: true
+      ecomobs.command.spawner.*: true
 
   ecomobs.command.ecomobs:
     description: Allows the use of /ecomobs
@@ -53,4 +55,80 @@ permissions:
 
   ecomobs.command.reload:
     description: Allows the use of /ecomobs reload
+    default: op
+
+  ecomobs.command.spawner.*:
+    description: All spawner commands
+    default: op
+    children:
+      ecomobs.command.spawner.give: true
+      ecomobs.command.spawner.modify: true
+      ecomobs.command.spawner.modify.*: true
+
+  ecomobs.command.spawner.give:
+    description: Give spawner items
+    default: op
+
+  ecomobs.command.spawner.modify:
+    description: Use /ecomobs spawner modify
+    default: op
+
+  ecomobs.command.spawner.modify.*:
+    description: Modify all spawner attributes
+    default: op
+    children:
+      ecomobs.command.spawner.modify.mob: true
+      ecomobs.command.spawner.modify.delay: true
+      ecomobs.command.spawner.modify.radius: true
+      ecomobs.command.spawner.modify.player-radius: true
+      ecomobs.command.spawner.modify.count: true
+      ecomobs.command.spawner.modify.max-count: true
+      ecomobs.command.spawner.modify.pickup: true
+      ecomobs.command.spawner.modify.particle: true
+
+  ecomobs.command.spawner.modify.mob:
+    description: Modify spawner mob type
+    default: op
+
+  ecomobs.command.spawner.modify.delay:
+    description: Modify spawner delay
+    default: op
+
+  ecomobs.command.spawner.modify.radius:
+    description: Modify spawner spawn radius
+    default: op
+
+  ecomobs.command.spawner.modify.player-radius:
+    description: Modify spawner required player radius
+    default: op
+
+  ecomobs.command.spawner.modify.count:
+    description: Modify spawner spawn count
+    default: op
+
+  ecomobs.command.spawner.modify.max-count:
+    description: Modify spawner max nearby entities
+    default: op
+
+  ecomobs.command.spawner.modify.pickup:
+    description: Modify spawner pickup mode
+    default: op
+
+  ecomobs.command.spawner.modify.particle:
+    description: Modify spawner particle animation
+    default: op
+
+  ecomobs.spawner.*:
+    description: Spawner runtime permissions
+    default: op
+    children:
+      ecomobs.spawner.pickup: true
+      ecomobs.spawner.pickup.silktouch: true
+
+  ecomobs.spawner.pickup:
+    description: Pick up spawners when pickup mode is 'allow'
+    default: op
+
+  ecomobs.spawner.pickup.silktouch:
+    description: Pick up spawners with silk touch when pickup mode is 'silk_touch'
     default: op

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -82,9 +82,10 @@ permissions:
       ecomobs.command.spawner.modify.radius: true
       ecomobs.command.spawner.modify.player-radius: true
       ecomobs.command.spawner.modify.count: true
-      ecomobs.command.spawner.modify.max-count: true
+      ecomobs.command.spawner.modify.max-nearby: true
       ecomobs.command.spawner.modify.pickup: true
       ecomobs.command.spawner.modify.particle: true
+      ecomobs.command.spawner.modify.explosion-proof: true
 
   ecomobs.command.spawner.modify.mob:
     description: Modify spawner mob type
@@ -106,7 +107,7 @@ permissions:
     description: Modify spawner spawn count
     default: op
 
-  ecomobs.command.spawner.modify.max-count:
+  ecomobs.command.spawner.modify.max-nearby:
     description: Modify spawner max nearby entities
     default: op
 
@@ -116,6 +117,10 @@ permissions:
 
   ecomobs.command.spawner.modify.particle:
     description: Modify spawner particle animation
+    default: op
+
+  ecomobs.command.spawner.modify.explosion-proof:
+    description: Modify spawner explosion-proof setting
     default: op
 
   ecomobs.spawner.*:

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 #Mon Apr 20 17:52:29 BST 2026
 kotlin.code.style=official
 libreforge-version=5.2.1
-version=11.2.1
+version=11.3.0


### PR DESCRIPTION
## Spawners

Custom spawners for both EcoMobs and vanilla mobs, fully configurable via commands. Spawner items are vanilla SPAWNER blocks with all settings stored in NBT.

---

### Commands

```
/ecomobs spawner give <player> <mob> [amount]
  Give a spawner item. Defaults: delay 200-800t, radius 4, player-range 16, count 4, max-nearby 6, pickup deny.

/ecomobs spawner modify mob <mob_id>
  Change what mob the spawner (held or looked-at) spawns. Accepts EcoMob IDs or vanilla entity types (e.g. zombie, creeper).

/ecomobs spawner modify delay <min> <max>
  Set spawn delay range in ticks (e.g. delay 200 800).

/ecomobs spawner modify radius <value>
  Set the radius mobs can appear within.

/ecomobs spawner modify player-radius <value>
  Set how close a player must be for the spawner to activate.

/ecomobs spawner modify count <value>
  Set how many mobs spawn per activation.

/ecomobs spawner modify max-count <value>
  Set the max nearby entities before spawning pauses.

/ecomobs spawner modify pickup <allow|silk_touch|deny>
  Set pickup behaviour. allow = any break, silk_touch = requires silk touch tool, deny = never drops.

/ecomobs spawner modify particle <animation_id|none>
  Set a particle animation around the placed spawner. Animation IDs are defined in config.yml under spawner-animations.
```

Modify targets the held spawner item first; if not holding one, targets the block you're looking at (within 5 blocks).

---

### Permissions

```
ecomobs.command.spawner.give            Give spawner items
ecomobs.command.spawner.modify          Use the modify command
ecomobs.command.spawner.modify.mob      Modify mob type
ecomobs.command.spawner.modify.delay    Modify delay
ecomobs.command.spawner.modify.radius   Modify spawn radius
ecomobs.command.spawner.modify.player-radius  Modify player activation radius
ecomobs.command.spawner.modify.count    Modify spawn count
ecomobs.command.spawner.modify.max-count     Modify max nearby entities
ecomobs.command.spawner.modify.pickup   Modify pickup mode
ecomobs.command.spawner.modify.particle Modify particle animation

ecomobs.spawner.pickup                  Pick up spawners (mode: allow)
ecomobs.spawner.pickup.silktouch        Pick up spawners with silk touch (mode: silk_touch)

ecomobs.command.spawner.*               All spawner commands
ecomobs.command.spawner.modify.*        All modify attributes
ecomobs.spawner.*                       All pickup permissions
```

---

### Particle Animations

Defined in config.yml under spawner-animations. Each entry specifies a particle type and one of the built-in animation shapes: circle, spiral, double_spiral, tilted_rings, twirl. Animation shape settings (radius, height, speed etc.) are configured under animations in config.yml.
